### PR TITLE
Handle missing whatsappId for scheduled messages

### DIFF
--- a/backend/src/__tests__/scheduleCreate.spec.ts
+++ b/backend/src/__tests__/scheduleCreate.spec.ts
@@ -1,0 +1,23 @@
+import CreateService from "../services/ScheduleServices/CreateService";
+import Schedule from "../models/Schedule";
+
+describe("Schedule CreateService", () => {
+  it("should create schedule without whatsappId", async () => {
+    const reload = jest.fn().mockResolvedValue(null);
+    const scheduleMock = { reload } as any;
+    const createSpy = jest
+      .spyOn(Schedule, "create")
+      .mockResolvedValue(scheduleMock);
+
+    await CreateService({
+      body: "test message",
+      sendAt: new Date().toISOString(),
+      contactId: 1,
+      companyId: 1
+    } as any);
+
+    expect(createSpy).toHaveBeenCalled();
+    const passedData = createSpy.mock.calls[0][0] as any;
+    expect(passedData.whatsappId).toBeUndefined();
+  });
+});

--- a/backend/src/helpers/GetDefaultWhatsApp.ts
+++ b/backend/src/helpers/GetDefaultWhatsApp.ts
@@ -3,7 +3,7 @@ import Whatsapp from "../models/Whatsapp";
 import GetDefaultWhatsAppByUser from "./GetDefaultWhatsAppByUser";
 
 const GetDefaultWhatsApp = async (
-  whatsappId?: number,
+  whatsappId: number | null = null,
   companyId: number | null = null,
   userId?: number
 ): Promise<Whatsapp> => {
@@ -12,7 +12,7 @@ const GetDefaultWhatsApp = async (
 
   console.log({ whatsappId, companyId, userId })
   
-  if (whatsappId) {
+  if (whatsappId !== null) {
     defaultWhatsapp = await Whatsapp.findOne({
       where: { id: whatsappId, companyId }
     });

--- a/backend/src/queues.ts
+++ b/backend/src/queues.ts
@@ -188,7 +188,7 @@ async function handleSendScheduledMessage(job) {
     }
 
     if (!whatsapp)
-      whatsapp = await GetDefaultWhatsApp(whatsapp.id,schedule.companyId);
+      whatsapp = await GetDefaultWhatsApp(null, schedule.companyId);
 
 
     // const settings = await CompaniesSettings.findOne({


### PR DESCRIPTION
## Summary
- avoid accessing whatsapp.id when undefined in queue processing
- allow GetDefaultWhatsApp to accept null whatsappId
- add test for creating schedules without whatsappId

## Testing
- `SKIP_DB=true npm test`
- `npm run lint` *(fails: Cannot read config file: ... eslint-config-prettier/@typescript-eslint.js)*

------
https://chatgpt.com/codex/tasks/task_e_688ed320ba108333a485bd717e02135f