### PR TITLE
fix: ajustar busca em mensagens agendadas

### DIFF
--- a/backend/src/services/ScheduledMessagesService/ListService.ts
+++ b/backend/src/services/ScheduledMessagesService/ListService.ts
@@ -18,29 +18,33 @@ const ListService = async ({
   pageNumber = "1",
   companyId
 }: Request): Promise<Response> => {
+  const sanitizedSearchParam = searchParam
+    ? searchParam.toLowerCase().trim()
+    : "";
+
   let whereCondition = {};
   const limit = 20;
   const offset = limit * (+pageNumber - 1);
 
-  if (!!searchParam) {
+  if (sanitizedSearchParam) {
     whereCondition = {
       [Op.or]: [
         {
-          "$Schedule.body$": Sequelize.where(
-            Sequelize.fn("LOWER", Sequelize.col("Schedule.message")),
+          mensagem: Sequelize.where(
+            Sequelize.fn("LOWER", Sequelize.col("mensagem")),
             "LIKE",
-            `%${searchParam.toLowerCase()}%`
+            `%${sanitizedSearchParam}%`
           )
         },
         {
-          "$Contact.name$": Sequelize.where(
-            Sequelize.fn("LOWER", Sequelize.col("contact.name")),
+          nome: Sequelize.where(
+            Sequelize.fn("LOWER", Sequelize.col("nome")),
             "LIKE",
-            `%${searchParam.toLowerCase()}%`
+            `%${sanitizedSearchParam}%`
           )
-        },
-      ],
-    }
+        }
+      ]
+    };
   }
 
   whereCondition = {


### PR DESCRIPTION
## Summary
- utilizar campos `mensagem` e `nome` em vez de `Schedule` e `Contact`
- remover associações inexistentes na busca

## Testing
- `SKIP_DB=true npm test`
- `node -r ts-node/register/transpile-only <<'NODE'` (script demonstrando busca por texto)


------
https://chatgpt.com/codex/tasks/task_e_688ed4de2ea483338a3bc6fd1f862e0d