### PR TITLE
feat: track scheduled message deliveries

### DIFF
--- a/backend/src/controllers/ScheduledMessagesController.ts
+++ b/backend/src/controllers/ScheduledMessagesController.ts
@@ -9,6 +9,7 @@ import ListService from "../services/ScheduledMessagesService/ListService";
 import UpdateService from "../services/ScheduledMessagesService/UpdateService";
 import ShowService from "../services/ScheduledMessagesService/ShowService";
 import DeleteService from "../services/ScheduledMessagesService/DeleteService";
+import ListEnvioService from "../services/ScheduledMessagesEnvioService/ListService";
 
 type IndexQuery = {
     searchParam?: string;
@@ -75,6 +76,15 @@ export const show = async (req: Request, res: Response): Promise<Response> => {
     const schedule = await ShowService(scheduleId);
 
     return res.status(200).json(schedule);
+};
+
+export const history = async (req: Request, res: Response): Promise<Response> => {
+    const { scheduleId } = req.params;
+    const { companyId } = req.user;
+
+    const envios = await ListEnvioService({ scheduleId: +scheduleId, companyId: +companyId });
+
+    return res.status(200).json(envios);
 };
 
 export const update = async (req: Request, res: Response): Promise<Response> => {

--- a/backend/src/routes/ScheduledMessagesRoutes.ts
+++ b/backend/src/routes/ScheduledMessagesRoutes.ts
@@ -15,6 +15,7 @@ scheduleMessageRoutes.post("/schedules-message", isAuth, upload.array("file"), S
 scheduleMessageRoutes.put("/schedules-message/:scheduleId", isAuth, upload.array("file"), ScheduleMesageController.update);
 
 scheduleMessageRoutes.get("/schedules-message/:scheduleId", isAuth, ScheduleMesageController.show);
+scheduleMessageRoutes.get("/schedules-message/:scheduleId/history", isAuth, ScheduleMesageController.history);
 
 scheduleMessageRoutes.delete("/schedules-message/:scheduleId", isAuth, ScheduleMesageController.remove);
 


### PR DESCRIPTION
## Summary
- log each delivery of scheduled messages in ScheduledMessagesEnvio
- skip re-sending messages with existing delivery record
- expose API to fetch delivery history for a scheduled message

## Testing
- `npm test` *(fails: Cannot find "/workspace/whaticket_streamdigi/backend/dist/config/database.js". Have you run "sequelize init"?)*

------
https://chatgpt.com/codex/tasks/task_e_688edd41f3288333be7a4de2465c1225