### PR TITLE
refactor scheduled messages envio service

### DIFF
--- a/backend/src/services/ScheduledMessagesEnvioService/CreateService.ts
+++ b/backend/src/services/ScheduledMessagesEnvioService/CreateService.ts
@@ -23,8 +23,6 @@ const CreateService = async ({
   key
 }: Request): Promise<ScheduledMessagesEnvio> => {
   const schema = Yup.object().shape({
-    data_mensagem_programada: Yup.date().required(),
-    nome: Yup.string().required(),
     mediaPath: Yup.string(),
     mediaName: Yup.string(),
     mensagem: Yup.string().required(),
@@ -47,8 +45,6 @@ const CreateService = async ({
   } catch (err: any) {
     throw new AppError(err.message);
   }
-
-  console.log(mediaPath, mediaName)
 
   const schedule = await ScheduledMessagesEnvio.create(
     {

--- a/backend/src/services/ScheduledMessagesEnvioService/DeleteService.ts
+++ b/backend/src/services/ScheduledMessagesEnvioService/DeleteService.ts
@@ -1,8 +1,8 @@
-import ScheduledMessages from "../../models/ScheduledMessages";
+import ScheduledMessagesEnvio from "../../models/ScheduledMessagesEnvio";
 import AppError from "../../errors/AppError";
 
 const DeleteService = async (id: string | number, companyId: number, key: string): Promise<void> => {
-  const schedule = await ScheduledMessages.findOne({ where: { id, companyId, key } });
+  const schedule = await ScheduledMessagesEnvio.findOne({ where: { id, companyId, key } });
 
   if (!schedule) throw new AppError("ERR_NO_SCHEDULE_FOUND", 404);
 

--- a/backend/src/services/ScheduledMessagesEnvioService/ShowService.ts
+++ b/backend/src/services/ScheduledMessagesEnvioService/ShowService.ts
@@ -1,8 +1,8 @@
-import ScheduledMessages from "../../models/ScheduledMessages";
+import ScheduledMessagesEnvio from "../../models/ScheduledMessagesEnvio";
 import AppError from "../../errors/AppError";
 
-const ScheduleService = async (id: string | number): Promise<ScheduledMessages> => {
-  const schedule = await ScheduledMessages.findByPk(id);
+const ScheduleService = async (id: string | number): Promise<ScheduledMessagesEnvio> => {
+  const schedule = await ScheduledMessagesEnvio.findByPk(id);
 
   if (!schedule) {
     throw new AppError("ERR_NO_SCHEDULE_FOUND", 404);

--- a/backend/src/services/ScheduledMessagesEnvioService/UpdateService.ts
+++ b/backend/src/services/ScheduledMessagesEnvioService/UpdateService.ts
@@ -1,16 +1,14 @@
 import * as Yup from "yup";
 
 import AppError from "../../errors/AppError";
-import ScheduledMessages from "../../models/ScheduledMessages";
+import ScheduledMessagesEnvio from "../../models/ScheduledMessagesEnvio";
 import ShowService from "./ShowService";
-import Contact from "../../models/Contact";
-import Tag from "../../models/Tag";
 
 interface ScheduleData {
   mediaPath: string;
   mediaName: string;
   mensagem: string;
-  companyId: number
+  companyId: number;
   data_envio: Date;
   scheduledmessages: number;
   key: string;
@@ -22,16 +20,14 @@ interface Request {
   companyId: number;
 }
 
-const UpdateUserService = async ({
+const UpdateService = async ({
   scheduleData,
   id,
   companyId
-}: Request): Promise<ScheduledMessages | undefined> => {
+}: Request): Promise<ScheduledMessagesEnvio | undefined> => {
   const schedule = await ShowService(id);
 
   const schema = Yup.object().shape({
-    data_mensagem_programada: Yup.date().required(),
-    nome: Yup.string().required(),
     mediaPath: Yup.string(),
     mediaName: Yup.string(),
     mensagem: Yup.string().required(),
@@ -78,4 +74,4 @@ const UpdateUserService = async ({
   return schedule;
 };
 
-export default UpdateUserService;
+export default UpdateService;


### PR DESCRIPTION
## Summary
- replace ScheduledMessages model with ScheduledMessagesEnvio across envio services
- simplify Yup validation schemas to only real fields
- clean up console logs and rename UpdateUserService to UpdateService

## Testing
- `SKIP_DB=true npm test`
- `npm run lint` *(fails: Cannot read config file: eslint-config-prettier/@typescript-eslint.js)*

------
https://chatgpt.com/codex/tasks/task_e_688edf200cf88333aa3e5a476dd213e2