### PR TITLE
fix: remove default WhatsApp console log and add tests

### DIFF
--- a/backend/src/__tests__/getDefaultWhatsApp.spec.ts
+++ b/backend/src/__tests__/getDefaultWhatsApp.spec.ts
@@ -1,0 +1,24 @@
+import GetDefaultWhatsApp from "../helpers/GetDefaultWhatsApp";
+import Whatsapp from "../models/Whatsapp";
+
+describe("GetDefaultWhatsApp", () => {
+  it("should select default connection without console logs", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    const defaultWpp = { status: "CONNECTED" } as Whatsapp;
+    const findOneSpy = jest
+      .spyOn(Whatsapp, "findOne")
+      .mockResolvedValue(defaultWpp as any);
+
+    const result = await GetDefaultWhatsApp(null, 1);
+
+    expect(result).toBe(defaultWpp);
+    expect(findOneSpy).toHaveBeenCalledWith({
+      where: { status: "CONNECTED", companyId: 1, isDefault: true }
+    });
+    expect(logSpy).not.toHaveBeenCalled();
+
+    findOneSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+});

--- a/backend/src/helpers/GetDefaultWhatsApp.ts
+++ b/backend/src/helpers/GetDefaultWhatsApp.ts
@@ -10,8 +10,6 @@ const GetDefaultWhatsApp = async (
   let connection: Whatsapp;
   let defaultWhatsapp = null;
 
-  console.log({ whatsappId, companyId, userId })
-  
   if (whatsappId !== null) {
     defaultWhatsapp = await Whatsapp.findOne({
       where: { id: whatsappId, companyId }


### PR DESCRIPTION
## Summary
- remove debug console log from GetDefaultWhatsApp helper
- add integration test ensuring default connection selection without logging

## Testing
- `cd backend && SKIP_DB=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ee0e67c2483338332e882c0618cee