### PR TITLE
refactor: handle numeric scheduled message fields

### DIFF
--- a/backend/src/database/migrations/20240102230240-create-ScheduledMessages.ts
+++ b/backend/src/database/migrations/20240102230240-create-ScheduledMessages.ts
@@ -13,13 +13,13 @@ module.exports = {
         type: DataTypes.DATE
       },
       id_conexao: {
-        type: DataTypes.STRING
+        type: DataTypes.INTEGER
       },
       intervalo: {
-        type: DataTypes.STRING
+        type: DataTypes.INTEGER
       },
       valor_intervalo: {
-        type: DataTypes.STRING
+        type: DataTypes.INTEGER
       },
       mensagem: {
         type: DataTypes.TEXT
@@ -68,7 +68,7 @@ module.exports = {
         type: DataTypes.STRING
       },
       enviar_quantas_vezes: {
-        type: DataTypes.STRING
+        type: DataTypes.INTEGER
       }
     });
   },

--- a/backend/src/models/ScheduledMessages.ts
+++ b/backend/src/models/ScheduledMessages.ts
@@ -13,14 +13,14 @@ class ScheduledMessages extends Model<ScheduledMessages> {
     @Column
     data_mensagem_programada: Date;
 
-    @Column
-    id_conexao: String;
+    @Column(DataType.INTEGER)
+    id_conexao: number;
 
-    @Column
-    intervalo: string;
+    @Column(DataType.INTEGER)
+    intervalo: number;
 
-    @Column
-    valor_intervalo: string;
+    @Column(DataType.INTEGER)
+    valor_intervalo: number;
 
     @Column(DataType.TEXT)
     mensagem: string;
@@ -73,8 +73,8 @@ class ScheduledMessages extends Model<ScheduledMessages> {
     @Column
     usuario_envio: string;
 
-    @Column
-    enviar_quantas_vezes: string;
+    @Column(DataType.INTEGER)
+    enviar_quantas_vezes: number;
 
 }
 

--- a/backend/src/services/ScheduledMessagesService/CreateService.ts
+++ b/backend/src/services/ScheduledMessagesService/CreateService.ts
@@ -7,9 +7,9 @@ import Contact from "../../models/Contact";
 
 interface Request {
   data_mensagem_programada: Date;
-  id_conexao: String;
-  intervalo: string;
-  valor_intervalo: string;
+  id_conexao: number;
+  intervalo: number;
+  valor_intervalo: number;
   mensagem: string;
   tipo_dias_envio: string;
   mostrar_usuario_mensagem: boolean;
@@ -22,7 +22,7 @@ interface Request {
   mediaName: string;
   tipo_arquivo: string;
   usuario_envio: string;
-  enviar_quantas_vezes: string;
+  enviar_quantas_vezes: number;
 }
 
 const CreateService = async ({
@@ -47,14 +47,15 @@ const CreateService = async ({
   const schema = Yup.object().shape({
     data_mensagem_programada: Yup.date().required(),
     nome: Yup.string().required(),
-    intervalo: Yup.string().required(),
-    valor_intervalo: Yup.string().required(),
+    intervalo: Yup.number().required(),
+    valor_intervalo: Yup.number().required(),
     mensagem: Yup.string().required(),
     tipo_dias_envio: Yup.string().required(),
     mostrar_usuario_mensagem: Yup.boolean().required(),
     criar_ticket: Yup.boolean().required(),
     companyId: Yup.number().required(),
-    enviar_quantas_vezes: Yup.string().required(),
+    enviar_quantas_vezes: Yup.number().required(),
+    id_conexao: Yup.number().required(),
     mediaPath: Yup.string(),
     mediaName: Yup.string(),
     tipo_arquivo: Yup.string(),

--- a/backend/src/services/ScheduledMessagesService/IntervalUtils.ts
+++ b/backend/src/services/ScheduledMessagesService/IntervalUtils.ts
@@ -1,0 +1,35 @@
+export const calculateNextSendDate = (
+  sendAt: Date,
+  intervalo: number,
+  valor_intervalo: number
+): Date => {
+  const nextDate = new Date(sendAt);
+  switch (intervalo) {
+    case 1:
+      nextDate.setDate(nextDate.getDate() + valor_intervalo);
+      break;
+    case 2:
+      nextDate.setDate(nextDate.getDate() + valor_intervalo * 7);
+      break;
+    case 3:
+      nextDate.setMonth(nextDate.getMonth() + valor_intervalo);
+      break;
+    case 4:
+      nextDate.setMinutes(nextDate.getMinutes() + valor_intervalo);
+      break;
+    default:
+      throw new Error("INVALID_INTERVAL");
+  }
+  return nextDate;
+};
+
+export const shouldScheduleAgain = (
+  contadorEnvio: number | null | undefined,
+  enviar_quantas_vezes: number,
+  valor_intervalo: number
+): boolean => {
+  return (
+    valor_intervalo > 0 &&
+    (contadorEnvio == null || contadorEnvio < enviar_quantas_vezes)
+  );
+};

--- a/backend/src/services/ScheduledMessagesService/UpdateService.ts
+++ b/backend/src/services/ScheduledMessagesService/UpdateService.ts
@@ -6,9 +6,9 @@ import ShowService from "./ShowService";
 
 interface ScheduleData {
   data_mensagem_programada: Date;
-  id_conexao: String;
-  intervalo: string;
-  valor_intervalo: string;
+  id_conexao: number;
+  intervalo: number;
+  valor_intervalo: number;
   mensagem: string;
   tipo_dias_envio: string;
   mostrar_usuario_mensagem: boolean;
@@ -19,7 +19,7 @@ interface ScheduleData {
   nome: string;
   tipo_arquivo: string;
   usuario_envio: string;
-  enviar_quantas_vezes: string;
+  enviar_quantas_vezes: number;
   mediaName: string;
   mediaPath: string;
 }
@@ -59,18 +59,18 @@ const UpdateService = async ({
   const schema = Yup.object().shape({
     data_mensagem_programada: Yup.date().required(),
     nome: Yup.string().required(),
-    intervalo: Yup.string().required(),
-    valor_intervalo: Yup.string().required(),
+    intervalo: Yup.number().required(),
+    valor_intervalo: Yup.number().required(),
     mensagem: Yup.string().required(),
     tipo_dias_envio: Yup.string().required(),
     mostrar_usuario_mensagem: Yup.boolean().required(),
     criar_ticket: Yup.boolean().required(),
-    enviar_quantas_vezes: Yup.string().required(),
+    enviar_quantas_vezes: Yup.number().required(),
     mediaPath: Yup.string().nullable(),
     mediaName: Yup.string().nullable(),
     tipo_arquivo: Yup.string().nullable(),
     usuario_envio: Yup.string().nullable(),
-    id_conexao: Yup.string().required()
+    id_conexao: Yup.number().required()
   });
 
   try {

--- a/backend/src/services/ScheduledMessagesService/__tests__/IntervalUtils.spec.ts
+++ b/backend/src/services/ScheduledMessagesService/__tests__/IntervalUtils.spec.ts
@@ -1,0 +1,20 @@
+import { calculateNextSendDate, shouldScheduleAgain } from "../IntervalUtils";
+
+describe("IntervalUtils", () => {
+  it("calculates next date based on days interval", () => {
+    const start = new Date("2024-01-01T00:00:00Z");
+    const result = calculateNextSendDate(start, 1, 2);
+    expect(result.getTime()).toBe(start.getTime() + 2 * 24 * 60 * 60 * 1000);
+  });
+
+  it("calculates next date based on minutes interval", () => {
+    const start = new Date("2024-01-01T00:00:00Z");
+    const result = calculateNextSendDate(start, 4, 30);
+    expect(result.getTime()).toBe(start.getTime() + 30 * 60 * 1000);
+  });
+
+  it("enforces send limit", () => {
+    expect(shouldScheduleAgain(1, 2, 1)).toBe(true);
+    expect(shouldScheduleAgain(2, 2, 1)).toBe(false);
+  });
+});

--- a/backend/src/services/ScheduledMessagesService/__tests__/UpdateService.spec.ts
+++ b/backend/src/services/ScheduledMessagesService/__tests__/UpdateService.spec.ts
@@ -15,9 +15,9 @@ describe("ScheduledMessages UpdateService", () => {
 
     const scheduleData = {
       data_mensagem_programada: new Date(),
-      id_conexao: "1",
-      intervalo: "1",
-      valor_intervalo: "1",
+      id_conexao: 1,
+      intervalo: 1,
+      valor_intervalo: 1,
       mensagem: "msg",
       tipo_dias_envio: "day",
       mostrar_usuario_mensagem: true,
@@ -28,7 +28,7 @@ describe("ScheduledMessages UpdateService", () => {
       nome: "test",
       tipo_arquivo: "text",
       usuario_envio: "user",
-      enviar_quantas_vezes: "1",
+      enviar_quantas_vezes: 1,
       mediaName: "",
       mediaPath: ""
     } as any;
@@ -50,9 +50,9 @@ describe("ScheduledMessages UpdateService", () => {
 
     const scheduleData = {
       data_mensagem_programada: new Date(),
-      id_conexao: "1",
-      intervalo: "1",
-      valor_intervalo: "1",
+      id_conexao: 1,
+      intervalo: 1,
+      valor_intervalo: 1,
       mensagem: "msg",
       tipo_dias_envio: "day",
       mostrar_usuario_mensagem: false,
@@ -63,7 +63,7 @@ describe("ScheduledMessages UpdateService", () => {
       nome: "test",
       tipo_arquivo: "text",
       usuario_envio: "user",
-      enviar_quantas_vezes: "1",
+      enviar_quantas_vezes: 1,
       mediaName: "",
       mediaPath: ""
     } as any;


### PR DESCRIPTION
## Summary
- change ScheduledMessages columns to numeric types
- validate numeric schedule fields in creation and update services
- add utilities and tests for interval calculations and send limits

## Testing
- `SKIP_DB=true npm test`
- `npm run lint` *(fails: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier)*

------
https://chatgpt.com/codex/tasks/task_e_688ee29a70b083338b40d52513461fa2