### PR TITLE
chore: update ESLint prettier config

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -7,7 +7,7 @@
   "extends": [
     "airbnb-base",
     "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint",
+    "prettier",
     "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",


### PR DESCRIPTION
## Summary
- replace deprecated `prettier/@typescript-eslint` with `prettier` in backend ESLint config

## Testing
- `npm run lint` *(fails: 3203 problems)*

------
https://chatgpt.com/codex/tasks/task_e_688ee9d68e148333a0a6c288b8fb3eb4