### PR TITLE
refactor: validate campaign messages

### DIFF
--- a/backend/src/services/CampaignService/CreateService.ts
+++ b/backend/src/services/CampaignService/CreateService.ts
@@ -13,16 +13,8 @@ interface Data {
   scheduledAt: string;
   companyId: number;
   contactListId: number;
-  message1?: string;
-  message2?: string;
-  message3?: string;
-  message4?: string;
-  message5?: string;
-  confirmationMessage1?: string;
-  confirmationMessage2?: string;
-  confirmationMessage3?: string;
-  confirmationMessage4?: string;
-  confirmationMessage5?: string;
+  messages: string[];
+  confirmationMessages: string[];
   userId: number | string;
   queueId: number | string;
   statusTicket: string;
@@ -30,33 +22,54 @@ interface Data {
 }
 
 const CreateService = async (data: Data): Promise<Campaign> => {
-  const { name } = data;
-
-  const ticketnoteSchema = Yup.object().shape({
+  const campaignSchema = Yup.object().shape({
     name: Yup.string()
       .min(3, "ERR_CAMPAIGN_INVALID_NAME")
-      .required("ERR_CAMPAIGN_REQUIRED")
+      .required("ERR_CAMPAIGN_REQUIRED"),
+    scheduledAt: Yup.date()
+      .nullable()
+      .typeError("ERR_CAMPAIGN_INVALID_SCHEDULE"),
+    status: Yup.string().required("ERR_CAMPAIGN_REQUIRED"),
+    messages: Yup.array()
+      .of(Yup.string().required("ERR_CAMPAIGN_REQUIRED"))
+      .required("ERR_CAMPAIGN_REQUIRED"),
+    confirmationMessages: Yup.array()
+      .of(Yup.string().required("ERR_CAMPAIGN_REQUIRED"))
   });
 
   try {
-    await ticketnoteSchema.validate({ name });
+    await campaignSchema.validate(data);
   } catch (err: any) {
     throw new AppError(err.message);
   }
 
-  if (data.scheduledAt != null && data.scheduledAt != "") {
+  if (data.scheduledAt != null && data.scheduledAt !== "") {
     data.status = "PROGRAMADA";
   }
 
-  const record = await Campaign.create(data);
+  const { messages = [], confirmationMessages = [], ...campaignData } = data;
+
+  const record = await Campaign.create({
+    ...campaignData,
+    message1: messages[0],
+    message2: messages[1],
+    message3: messages[2],
+    message4: messages[3],
+    message5: messages[4],
+    confirmationMessage1: confirmationMessages[0],
+    confirmationMessage2: confirmationMessages[1],
+    confirmationMessage3: confirmationMessages[2],
+    confirmationMessage4: confirmationMessages[3],
+    confirmationMessage5: confirmationMessages[4]
+  });
 
   await record.reload({
     include: [
       { model: ContactList },
       { model: Whatsapp, attributes: ["id", "name"] },
       { model: User, attributes: ["id", "name"] },
-      { model: Queue, attributes: ["id", "name"] },
-        ]
+      { model: Queue, attributes: ["id", "name"] }
+    ]
   });
 
   return record;

--- a/backend/src/services/CampaignService/UpdateService.ts
+++ b/backend/src/services/CampaignService/UpdateService.ts
@@ -1,3 +1,4 @@
+import * as Yup from "yup";
 import AppError from "../../errors/AppError";
 import Campaign from "../../models/Campaign";
 import ContactList from "../../models/ContactList";
@@ -13,16 +14,8 @@ interface Data {
   scheduledAt: string;
   companyId: number;
   contactListId: number;
-  message1?: string;
-  message2?: string;
-  message3?: string;
-  message4?: string;
-  message5?: string;
-  confirmationMessage1?: string;
-  confirmationMessage2?: string;
-  confirmationMessage3?: string;
-  confirmationMessage4?: string;
-  confirmationMessage5?: string;
+  messages: string[];
+  confirmationMessages: string[];
   userId: number | string;
   queueId: number | string;
   statusTicket: string;
@@ -38,6 +31,28 @@ const UpdateService = async (data: Data): Promise<Campaign> => {
     throw new AppError("ERR_NO_CAMPAIGN_FOUND", 404);
   }
 
+  const campaignSchema = Yup.object().shape({
+    name: Yup.string()
+      .min(3, "ERR_CAMPAIGN_INVALID_NAME")
+      .required("ERR_CAMPAIGN_REQUIRED"),
+    scheduledAt: Yup.date()
+      .nullable()
+      .typeError("ERR_CAMPAIGN_INVALID_SCHEDULE"),
+    status: Yup.string().required("ERR_CAMPAIGN_REQUIRED"),
+    messages: Yup.array()
+      .of(Yup.string().required("ERR_CAMPAIGN_REQUIRED"))
+      .required("ERR_CAMPAIGN_REQUIRED"),
+    confirmationMessages: Yup.array().of(
+      Yup.string().required("ERR_CAMPAIGN_REQUIRED")
+    )
+  });
+
+  try {
+    await campaignSchema.validate(data);
+  } catch (err: any) {
+    throw new AppError(err.message);
+  }
+
   if (["INATIVA", "PROGRAMADA", "CANCELADA"].indexOf(data.status) === -1) {
     throw new AppError(
       "Solo se permite modificar campañas Inactivas y Programadas",
@@ -47,20 +62,34 @@ const UpdateService = async (data: Data): Promise<Campaign> => {
 
   if (
     data.scheduledAt != null &&
-    data.scheduledAt != "" &&
+    data.scheduledAt !== "" &&
     data.status === "INATIVA"
   ) {
     data.status = "PROGRAMADA";
   }
 
-  await record.update(data);
+  const { messages = [], confirmationMessages = [], ...campaignData } = data;
+
+  await record.update({
+    ...campaignData,
+    message1: messages[0],
+    message2: messages[1],
+    message3: messages[2],
+    message4: messages[3],
+    message5: messages[4],
+    confirmationMessage1: confirmationMessages[0],
+    confirmationMessage2: confirmationMessages[1],
+    confirmationMessage3: confirmationMessages[2],
+    confirmationMessage4: confirmationMessages[3],
+    confirmationMessage5: confirmationMessages[4]
+  });
 
   await record.reload({
     include: [
       { model: ContactList },
       { model: Whatsapp, attributes: ["id", "name"] },
       { model: User, attributes: ["id", "name"] },
-      { model: Queue, attributes: ["id", "name"] },
+      { model: Queue, attributes: ["id", "name"] }
     ]
   });
 


### PR DESCRIPTION
## Summary
- add schema validating campaign dates, status and message arrays
- replace message1..5 structure with array-based input
- mirror validation and mapping in update service

## Testing
- `SKIP_DB=true npm test`
- `npm run lint` *(fails: 2948 errors, 255 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688f7b401b848333a683f430544cf480