### PR TITLE
Check duplicate contact lists and add indexes

### DIFF
--- a/backend/src/controllers/ContactListController.ts
+++ b/backend/src/controllers/ContactListController.ts
@@ -16,9 +16,10 @@ import AppError from "../errors/AppError";
 import { ImportContacts } from "../services/ContactListService/ImportContacts";
 
 type IndexQuery = {
-  searchParam: string;
-  pageNumber: string;
-  companyId: string | number;
+  searchParam?: string;
+  pageNumber?: string;
+  limit?: string;
+  offset?: string;
 };
 
 type StoreData = {
@@ -31,13 +32,15 @@ type FindParams = {
 };
 
 export const index = async (req: Request, res: Response): Promise<Response> => {
-  const { searchParam, pageNumber } = req.query as IndexQuery;
+  const { searchParam, pageNumber, limit, offset } = req.query as IndexQuery;
   const { companyId } = req.user;
 
   const { records, count, hasMore } = await ListService({
     searchParam,
     pageNumber,
-    companyId
+    companyId,
+    limit,
+    offset
   });
 
   return res.json({ records, count, hasMore });

--- a/backend/src/database/migrations/20240715100000-add-indexes-contactlist.ts
+++ b/backend/src/database/migrations/20240715100000-add-indexes-contactlist.ts
@@ -1,0 +1,18 @@
+import { QueryInterface } from "sequelize";
+
+module.exports = {
+  up: async (queryInterface: QueryInterface) => {
+    await queryInterface.addIndex("ContactLists", ["name"], {
+      name: "idx_contactlist_name"
+    });
+    await queryInterface.addIndex("ContactListItems", ["number"], {
+      name: "idx_contactlistitem_number"
+    });
+  },
+
+  down: async (queryInterface: QueryInterface) => {
+    await queryInterface.removeIndex("ContactLists", "idx_contactlist_name");
+    await queryInterface.removeIndex("ContactListItems", "idx_contactlistitem_number");
+  }
+};
+

--- a/backend/src/services/ContactListService/CreateService.ts
+++ b/backend/src/services/ContactListService/CreateService.ts
@@ -22,6 +22,14 @@ const CreateService = async (data: Data): Promise<ContactList> => {
     throw new AppError(err.message);
   }
 
+  const contactListExists = await ContactList.findOne({
+    where: { name, companyId }
+  });
+
+  if (contactListExists) {
+    throw new AppError("ERR_DUPLICATED_CONTACTLIST");
+  }
+
   const record = await ContactList.create(data);
 
   return record;

--- a/backend/src/services/ContactListService/ListService.ts
+++ b/backend/src/services/ContactListService/ListService.ts
@@ -7,6 +7,8 @@ interface Request {
   companyId: number | string;
   searchParam?: string;
   pageNumber?: string;
+  limit?: string;
+  offset?: string;
 }
 
 interface Response {
@@ -18,7 +20,9 @@ interface Response {
 const ListService = async ({
   searchParam = "",
   pageNumber = "1",
-  companyId
+  companyId,
+  limit = "20",
+  offset
 }: Request): Promise<Response> => {
   let whereCondition: any = {
     companyId
@@ -41,13 +45,13 @@ const ListService = async ({
     };
   }
 
-  const limit = 20;
-  const offset = limit * (+pageNumber - 1);
+  const limitNumber = +limit;
+  const offsetNumber = offset ? +offset : limitNumber * (+pageNumber - 1);
 
   const { count, rows: records } = await ContactList.findAndCountAll({
     where: whereCondition,
-    limit,
-    offset,
+    limit: limitNumber,
+    offset: offsetNumber,
     order: [["name", "ASC"]],
     subQuery: false,
     include: [
@@ -66,7 +70,7 @@ const ListService = async ({
     group: ["ContactList.id"]
   });
 
-  const hasMore = count > offset + records.length;
+  const hasMore = count > offsetNumber + records.length;
 
   return {
     records,


### PR DESCRIPTION
## Summary
- prevent creating duplicated contact lists per company
- add indexes for contact list name and list item number
- allow clients to supply limit/offset for contact list listing

## Testing
- `cd backend && SKIP_DB=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_688f9059cc64833398056869e0e090e9