### PR TITLE
chore: streamline prettier config

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,8 +1,3 @@
 {
-  "extends": [
-    "airbnb-base",
-    "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "plugin:prettier/recommended"
-  ]
+  "extends": ["airbnb-base", "plugin:@typescript-eslint/recommended", "prettier", "plugin:prettier/recommended"]
 }


### PR DESCRIPTION
## Summary
- streamline ESLint extends to rely on Prettier after TypeScript rules

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin'; dependency install returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_688fcc6b2ba083338c7fe2f41a6e485b