### PR TITLE
Default schedule margin to 300 on invalid env

### DIFF
--- a/backend/src/__tests__/scheduleTimeRange.spec.ts
+++ b/backend/src/__tests__/scheduleTimeRange.spec.ts
@@ -2,6 +2,12 @@ import moment from "moment";
 import { scheduleTimeWindow } from "../helpers/scheduleTimeRange";
 
 describe("scheduleTimeWindow", () => {
+  const originalEnv = process.env.SCHEDULE_MARGIN_SECONDS;
+
+  afterEach(() => {
+    process.env.SCHEDULE_MARGIN_SECONDS = originalEnv;
+  });
+
   it("captures times within margin even with different seconds", () => {
     const margin = 30;
     const [start, end] = scheduleTimeWindow(margin);
@@ -13,5 +19,19 @@ describe("scheduleTimeWindow", () => {
     expect(insideFuture.isBetween(start, end, undefined, "[]")).toBe(true);
     expect(insidePast.isBetween(start, end, undefined, "[]")).toBe(true);
     expect(outsideFuture.isBetween(start, end, undefined, "[]")).toBe(false);
+  });
+
+  it("defaults to 300 seconds when SCHEDULE_MARGIN_SECONDS is not a number", () => {
+    process.env.SCHEDULE_MARGIN_SECONDS = "abc" as any;
+    const [start, end] = scheduleTimeWindow();
+    const diff = moment(end).diff(moment(start), "seconds");
+    expect(diff).toBe(600);
+  });
+
+  it("defaults to 300 seconds when SCHEDULE_MARGIN_SECONDS is non-positive", () => {
+    process.env.SCHEDULE_MARGIN_SECONDS = "-10";
+    const [start, end] = scheduleTimeWindow();
+    const diff = moment(end).diff(moment(start), "seconds");
+    expect(diff).toBe(600);
   });
 });

--- a/backend/src/helpers/scheduleTimeRange.ts
+++ b/backend/src/helpers/scheduleTimeRange.ts
@@ -7,9 +7,10 @@ import moment from "moment";
 export const scheduleTimeWindow = (
   marginSeconds?: number
 ): [string, string] => {
-  const margin =
-    marginSeconds ??
-    parseInt(process.env.SCHEDULE_MARGIN_SECONDS || "300", 10);
+  const envMargin = Number(process.env.SCHEDULE_MARGIN_SECONDS);
+  const parsedEnvMargin =
+    Number.isNaN(envMargin) || envMargin <= 0 ? 300 : envMargin;
+  const margin = marginSeconds ?? parsedEnvMargin;
 
   const start = moment()
     .subtract(margin, "seconds")


### PR DESCRIPTION
## Summary
- parse SCHEDULE_MARGIN_SECONDS with Number and default to 300 when invalid
- add tests verifying 300-second default on invalid SCHEDULE_MARGIN_SECONDS

## Testing
- `SKIP_DB=true npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_688fd02c88e48333a6c0277431075029