### PR TITLE
feat: make scheduled message window configurable

### DIFF
--- a/backend/.env.exemple
+++ b/backend/.env.exemple
@@ -21,6 +21,9 @@ MASTER_KEY=senha_master
 
 TIMEOUT_TO_IMPORT_MESSAGE=1000
 
+# Time window margin in seconds for scheduled messages
+SCHEDULE_MARGIN_SECONDS=300
+
 # CREDENCIAIS DO REDIS
 REDIS_URI=redis://:suaSenha@127.0.0.1:6379
 REDIS_OPT_LIMITER_MAX=1

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -7,7 +7,7 @@
   "extends": [
     "airbnb-base",
     "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint",
+    "prettier",
     "plugin:prettier/recommended"
   ],
   "parser": "@typescript-eslint/parser",

--- a/backend/src/helpers/scheduleTimeRange.ts
+++ b/backend/src/helpers/scheduleTimeRange.ts
@@ -4,12 +4,18 @@ import moment from "moment";
  * Returns start and end timestamps for schedule verification window.
  * @param marginSeconds number of seconds before and after the current time
  */
-export const scheduleTimeWindow = (marginSeconds = 30): [string, string] => {
+export const scheduleTimeWindow = (
+  marginSeconds?: number
+): [string, string] => {
+  const margin =
+    marginSeconds ??
+    parseInt(process.env.SCHEDULE_MARGIN_SECONDS || "300", 10);
+
   const start = moment()
-    .subtract(marginSeconds, "seconds")
+    .subtract(margin, "seconds")
     .format("YYYY-MM-DD HH:mm:ss");
   const end = moment()
-    .add(marginSeconds, "seconds")
+    .add(margin, "seconds")
     .format("YYYY-MM-DD HH:mm:ss");
   return [start, end];
 };

--- a/backend/src/queues.ts
+++ b/backend/src/queues.ts
@@ -1811,7 +1811,7 @@ export async function startQueueProcess() {
     "Verify",
     {},
     {
-      repeat: { cron: "*/5 * * * * *", key: "verify" },
+      repeat: { cron: "*/30 * * * * *", key: "verify" },
       removeOnComplete: true
     }
   );


### PR DESCRIPTION
## Summary
- allow customizing scheduled message margin via `SCHEDULE_MARGIN_SECONDS`
- widen monitor cron to run every 30s so long delays are handled
- drop deprecated prettier/@typescript-eslint config to restore linting

## Testing
- `SKIP_DB=true npm test` *(fails: sh: 1: jest: not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_688ee72b471083338b3e312c3e0dbe87