### PR TITLE
chore: refine eslint config

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,3 +1,8 @@
 {
-  "extends": ["airbnb-base", "plugin:@typescript-eslint/recommended", "prettier", "plugin:prettier/recommended"]
+  "extends": [
+    "airbnb-base",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "plugin:prettier/recommended"
+  ]
 }


### PR DESCRIPTION
## Summary
- keep TypeScript ESLint and Prettier extends in backend ESLint config

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin' imported from backend/eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_688fda0d9c8883339e5bf71dc9ecdf46