### PR TITLE
fix: validate schedule margin

### DIFF
--- a/backend/src/helpers/scheduleTimeRange.ts
+++ b/backend/src/helpers/scheduleTimeRange.ts
@@ -2,7 +2,7 @@ import moment from "moment";
 
 const envMargin = Number(process.env.SCHEDULE_MARGIN_SECONDS);
 export const SCHEDULE_MARGIN_SECONDS =
-  Number.isNaN(envMargin) || envMargin <= 0 ? 300 : envMargin;
+  Number.isFinite(envMargin) && envMargin >= 0 ? envMargin : 300;
 
 /**
  * Returns start and end timestamps for schedule verification window.


### PR DESCRIPTION
## Summary
- ensure SCHEDULE_MARGIN_SECONDS is finite and non-negative with 300s fallback
- test schedule margin for valid, invalid, negative, and missing env values

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `SKIP_DB=true npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fe8edc514833395d0500bde4b3ddd