### PR TITLE
feat: make schedule monitor interval configurable

### DIFF
--- a/backend/.env.exemple
+++ b/backend/.env.exemple
@@ -24,6 +24,10 @@ TIMEOUT_TO_IMPORT_MESSAGE=1000
 # Time window margin in seconds for scheduled messages
 SCHEDULE_MARGIN_SECONDS=300
 
+# Cron expression for schedule monitor (default every 30s).
+# Values below 10 seconds may impact performance.
+SCHEDULE_MONITOR_INTERVAL=*/30 * * * * *
+
 # CREDENCIAIS DO REDIS
 REDIS_URI=redis://:suaSenha@127.0.0.1:6379
 REDIS_OPT_LIMITER_MAX=1

--- a/backend/src/queues.ts
+++ b/backend/src/queues.ts
@@ -52,6 +52,8 @@ import parseSpintax from "./helpers/parseSpintax";
 const connection = process.env.REDIS_URI || "";
 const limiterMax = process.env.REDIS_OPT_LIMITER_MAX || 1;
 const limiterDuration = process.env.REDIS_OPT_LIMITER_DURATION || 3000;
+const scheduleMonitorInterval =
+  process.env.SCHEDULE_MONITOR_INTERVAL || "*/30 * * * * *";
 
 interface ProcessCampaignData {
   id: number;
@@ -1864,7 +1866,7 @@ export async function startQueueProcess() {
     "Verify",
     {},
     {
-      repeat: { cron: "*/30 * * * * *", key: "verify" },
+      repeat: { cron: scheduleMonitorInterval, key: "verify" },
       removeOnComplete: true
     }
   );


### PR DESCRIPTION
## Summary
- allow changing schedule monitor interval via env var
- document schedule monitor interval env var

## Testing
- `SKIP_DB=true npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fea835d6483338422af452d22efeb