### PR TITLE
refactor: parse schedule margin env at call time

### DIFF
--- a/backend/src/__tests__/scheduleTimeRange.spec.ts
+++ b/backend/src/__tests__/scheduleTimeRange.spec.ts
@@ -31,11 +31,16 @@ describe("scheduleTimeWindow", () => {
     expect(diff).toBe(240);
   });
 
-  it("uses SCHEDULE_MARGIN_SECONDS when it is within range", () => {
+  it("reflects changes in SCHEDULE_MARGIN_SECONDS between calls", () => {
     process.env.SCHEDULE_MARGIN_SECONDS = "200";
-    const [start, end] = scheduleTimeWindow();
-    const diff = moment(end).diff(moment(start), "seconds");
+    let [start, end] = scheduleTimeWindow();
+    let diff = moment(end).diff(moment(start), "seconds");
     expect(diff).toBe(400);
+
+    process.env.SCHEDULE_MARGIN_SECONDS = "180";
+    [start, end] = scheduleTimeWindow();
+    diff = moment(end).diff(moment(start), "seconds");
+    expect(diff).toBe(360);
   });
 
   it("clamps SCHEDULE_MARGIN_SECONDS below minimum", () => {

--- a/backend/src/helpers/scheduleTimeRange.ts
+++ b/backend/src/helpers/scheduleTimeRange.ts
@@ -3,26 +3,26 @@ import moment from "moment";
 export const MIN_SCHEDULE_MARGIN_SECONDS = 120;
 export const MAX_SCHEDULE_MARGIN_SECONDS = 300;
 
-const envMargin = Number(process.env.SCHEDULE_MARGIN_SECONDS);
-const parsedEnvMargin = Number.isFinite(envMargin)
-  ? envMargin
-  : MAX_SCHEDULE_MARGIN_SECONDS;
-export const SCHEDULE_MARGIN_SECONDS = Math.min(
-  Math.max(parsedEnvMargin, MIN_SCHEDULE_MARGIN_SECONDS),
-  MAX_SCHEDULE_MARGIN_SECONDS
-);
-
 /**
  * Returns start and end timestamps for schedule verification window.
  * @param marginSeconds number of seconds before and after the current time
  */
 export const scheduleTimeWindow = (
-  marginSeconds: number = SCHEDULE_MARGIN_SECONDS
+  marginSeconds?: number
 ): [string, string] => {
+  const envMargin = Number(process.env.SCHEDULE_MARGIN_SECONDS);
+  const defaultMargin = Number.isFinite(envMargin)
+    ? envMargin
+    : MAX_SCHEDULE_MARGIN_SECONDS;
+
+  const marginValue =
+    marginSeconds === undefined ? defaultMargin : marginSeconds;
+
   const margin = Math.min(
-    Math.max(marginSeconds, MIN_SCHEDULE_MARGIN_SECONDS),
+    Math.max(marginValue, MIN_SCHEDULE_MARGIN_SECONDS),
     MAX_SCHEDULE_MARGIN_SECONDS
   );
+
   const start = moment()
     .subtract(margin, "seconds")
     .format("YYYY-MM-DD HH:mm:ss");


### PR DESCRIPTION
## Summary
- parse `SCHEDULE_MARGIN_SECONDS` within `scheduleTimeWindow`
- test scheduleTimeWindow reacts to env var changes

## Testing
- `SKIP_DB=true npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68911e53035c8333b3bc372a18555a95