### PR TITLE
feat: make server port configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@
    ```bash
    npm run build
    ```
+3. En producción, puedes definir el puerto mediante la variable de entorno `PORT` (el valor predeterminado es `3000`):
+   ```bash
+   PORT=8080 node server.js
+   ```
 
 ## Recursos externos
 - Documentación de [Node.js](https://nodejs.org/docs/latest/api/).

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -4,7 +4,7 @@ const path = require("path");
 const app = express();
 app.use(express.static(path.join(__dirname, "build")));
 app.get("/*", function (req, res) {
-	res.sendFile(path.join(__dirname, "build", "index.html"));
+        res.sendFile(path.join(__dirname, "build", "index.html"));
 });
-app.listen(3000);
+app.listen(process.env.PORT || 3000);
 


### PR DESCRIPTION
## Summary
- allow frontend server port to be set via PORT env var
- document configuring server port for production

## Testing
- `cd frontend && CI=true npm test -- --watchAll=false --passWithNoTests` *(fails: react-scripts not found)*
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@material-ui%2ficons)*

------
https://chatgpt.com/codex/tasks/task_e_6891250bc9388333bbe6ffec02c55987