### PR TITLE
test: add backend and frontend tests

### DIFF
--- a/backend/src/controllers/__tests__/VersionController.spec.ts
+++ b/backend/src/controllers/__tests__/VersionController.spec.ts
@@ -1,0 +1,39 @@
+import { index, store } from "../VersionController";
+import Version from "../../models/Versions";
+
+jest.mock("../../models/Versions");
+
+describe("VersionController", () => {
+  const mockStatus = jest.fn().mockReturnThis();
+  const mockJson = jest.fn();
+  const res: any = { status: mockStatus, json: mockJson };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStatus.mockReturnThis();
+  });
+
+  it("index should return current frontend version", async () => {
+    (Version as any).findByPk.mockResolvedValue({ versionFrontend: "1.0.0" });
+
+    await index({} as any, res);
+
+    expect(Version.findByPk).toHaveBeenCalledWith(1);
+    expect(mockStatus).toHaveBeenCalledWith(200);
+    expect(mockJson).toHaveBeenCalledWith({ version: "1.0.0" });
+  });
+
+  it("store should update frontend version", async () => {
+    const save = jest.fn();
+    const versionInstance = { versionFrontend: "1.0.0", save };
+    (Version as any).findByPk.mockResolvedValue(versionInstance);
+
+    const req: any = { body: { version: "2.0.0" } };
+
+    await store(req, res);
+
+    expect(versionInstance.versionFrontend).toBe("2.0.0");
+    expect(save).toHaveBeenCalled();
+    expect(mockJson).toHaveBeenCalledWith({ version: "2.0.0" });
+  });
+});

--- a/backend/src/services/WbotServices/__tests__/CheckNumber.spec.ts
+++ b/backend/src/services/WbotServices/__tests__/CheckNumber.spec.ts
@@ -1,0 +1,47 @@
+import AppError from "../../../errors/AppError";
+import CheckContactNumber from "../CheckNumber";
+import GetDefaultWhatsApp from "../../../helpers/GetDefaultWhatsApp";
+import { getWbot } from "../../../libs/wbot";
+
+jest.mock("../../../helpers/GetDefaultWhatsApp");
+jest.mock("../../../libs/wbot");
+
+const mockedGetDefaultWhatsApp = GetDefaultWhatsApp as jest.Mock;
+const mockedGetWbot = getWbot as jest.Mock;
+
+describe("CheckContactNumber", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should validate number and return jid without domain", async () => {
+    mockedGetDefaultWhatsApp.mockResolvedValue({ id: 1 });
+    const wbot = { onWhatsApp: jest.fn().mockResolvedValue([{ exists: true, jid: "123@s.whatsapp.net" }]) };
+    mockedGetWbot.mockReturnValue(wbot);
+
+    const result = await CheckContactNumber("123", 1, false);
+
+    expect(mockedGetDefaultWhatsApp).toHaveBeenCalledWith(null, 1);
+    expect(wbot.onWhatsApp).toHaveBeenCalledWith("123@s.whatsapp.net");
+    expect(result).toBe("123");
+  });
+
+  it("should throw AppError if number does not exist", async () => {
+    mockedGetDefaultWhatsApp.mockResolvedValue({ id: 1 });
+    const wbot = { onWhatsApp: jest.fn().mockResolvedValue([{ exists: false }]) };
+    mockedGetWbot.mockReturnValue(wbot);
+
+    await expect(CheckContactNumber("123", 1, false)).rejects.toBeInstanceOf(AppError);
+  });
+
+  it("should handle group numbers", async () => {
+    mockedGetDefaultWhatsApp.mockResolvedValue({ id: 1 });
+    const wbot = { groupMetadata: jest.fn().mockResolvedValue({ id: "123@g.us" }) };
+    mockedGetWbot.mockReturnValue(wbot);
+
+    const result = await CheckContactNumber("123@g.us", 1, true);
+
+    expect(wbot.groupMetadata).toHaveBeenCalledWith("123@g.us");
+    expect(result).toBe("123");
+  });
+});

--- a/frontend/src/components/ButtonWithSpinner/__tests__/ButtonWithSpinner.test.js
+++ b/frontend/src/components/ButtonWithSpinner/__tests__/ButtonWithSpinner.test.js
@@ -1,0 +1,15 @@
+import { render, screen } from "@testing-library/react";
+import ButtonWithSpinner from "../index";
+
+describe("ButtonWithSpinner", () => {
+  it("disables button and shows spinner when loading", () => {
+    render(<ButtonWithSpinner loading>Send</ButtonWithSpinner>);
+    expect(screen.getByRole("button")).toBeDisabled();
+    expect(screen.getByRole("progressbar")).toBeInTheDocument();
+  });
+
+  it("renders children when not loading", () => {
+    render(<ButtonWithSpinner loading={false}>Send</ButtonWithSpinner>);
+    expect(screen.getByText("Send")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Login/__tests__/Login.test.js
+++ b/frontend/src/pages/Login/__tests__/Login.test.js
@@ -1,0 +1,30 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import Login from "../index";
+import { AuthContext } from "../../../context/Auth/AuthContext";
+
+describe("Login page", () => {
+  it("submits user credentials", () => {
+    const handleLogin = jest.fn();
+
+    render(
+      <AuthContext.Provider value={{ handleLogin }}>
+        <Login />
+      </AuthContext.Provider>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Email/i), {
+      target: { value: "test@example.com" }
+    });
+    fireEvent.change(screen.getByLabelText(/Password/i), {
+      target: { value: "123456" }
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Entrar/i }));
+
+    expect(handleLogin).toHaveBeenCalledWith({
+      email: "test@example.com",
+      password: "123456",
+      remember: false
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add VersionController tests
- add CheckNumber service tests
- add React Testing Library tests for ButtonWithSpinner component and Login page

## Testing
- `SKIP_DB=true npx jest --runTestsByPath src/services/WbotServices/__tests__/CheckNumber.spec.ts src/controllers/__tests__/VersionController.spec.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68912c38035c83338a8374b94739c329