### PR TITLE
docs: add pm2 backend start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,15 @@
    ```bash
    npm run dev:server
    ```
-   Para producción:
+   Para producción (Node.js):
    ```bash
    npm run build
    npm start
+   ```
+   También puedes usar [PM2](https://pm2.keymetrics.io/) para administrar el proceso:
+   ```bash
+   npm run build
+   npm run start:pm2
    ```
 
 ## Ejecutar el frontend

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "start": "nodemon dist/server.js",
+    "start": "node dist/server.js",
+    "start:pm2": "pm2 start ecosystem.config.js",
     "dev:server": "ts-node-dev --respawn --transpile-only --ignore node_modules src/server.ts",
     "db:migrate": "npx sequelize db:migrate",
     "db:seed": "sequelize db:seed:all",


### PR DESCRIPTION
## Summary
- use compiled server for backend start script and expose PM2 script
- document how to launch backend in production via Node or PM2

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68914d4a5db88333b5a6aee2d3e763eb