### PR TITLE
chore: usar salida JSON en logger

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -69,7 +69,6 @@
     "openai": "^4.24.7",
     "pg": "^8.7.3",
     "pino": "^7.8.0",
-    "pino-pretty": "^10.0.0",
     "puppeteer": "^19.4.0",
     "puppeteer-core": "^22.13.1",
     "qrcode-terminal": "^0.12.0",

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -7,16 +7,10 @@ const timezoned = () => {
 };
 
 const logger = pino({
-  transport: {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-      levelFirst: true,
-      translateTime: 'SYS:dd-mm-yyyy HH:MM:ss', // Úsalo para traducir la hora
-      ignore: "pid,hostname"
-    },
-  },
   timestamp: () => `,"time":"${timezoned()}"`, // Añade el timestamp formateado
 });
+
+// Para redirigir los logs a un archivo o servicio externo, configura pino.destination
+// según la infraestructura disponible.
 
 export default logger;


### PR DESCRIPTION
## Summary
- remove pino-pretty transport and produce JSON logs
- remove leftover pino-pretty dependency

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm run lint` *(fails: @typescript-eslint/eslint-plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68914e1367b88333aea9959c5d3ae889