### PR TITLE
refactor: replace console logs with structured logging

### DIFF
--- a/backend/src/services/FlowBuilderService/CreateFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/CreateFlowBuilderService.ts
@@ -1,6 +1,7 @@
 import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   userId: number;
@@ -35,7 +36,7 @@ const CreateFlowBuilderService = async ({
 
     return flow;
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error
   }

--- a/backend/src/services/FlowBuilderService/DispatchWebHookService.ts
+++ b/backend/src/services/FlowBuilderService/DispatchWebHookService.ts
@@ -1,5 +1,6 @@
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   userId: number;
@@ -40,7 +41,7 @@ const DispatchWebHookService = async ({
 
     return webhook;
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error
   }

--- a/backend/src/services/FlowBuilderService/DuplicateFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/DuplicateFlowBuilderService.ts
@@ -1,6 +1,7 @@
 import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   id: number;
@@ -25,7 +26,7 @@ const DuplicateFlowBuilderService = async ({
 
     return duplicate;
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error;
   }

--- a/backend/src/services/FlowBuilderService/FlowUpdateDataService.ts
+++ b/backend/src/services/FlowBuilderService/FlowUpdateDataService.ts
@@ -1,6 +1,7 @@
 import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface node {
     id: string,
@@ -44,7 +45,7 @@ const FlowUpdateDataService = async ({
 
     return 'ok';
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error
   }

--- a/backend/src/services/FlowBuilderService/FlowsGetDataService.ts
+++ b/backend/src/services/FlowBuilderService/FlowsGetDataService.ts
@@ -1,6 +1,7 @@
 import { WebhookModel } from "../../models/Webhook";
 import User from "../../models/User";
 import { FlowBuilderModel } from "../../models/FlowBuilder";
+import logger from "../../utils/logger";
 
 interface Request {
   companyId: number;
@@ -31,7 +32,7 @@ const FlowsGetDataService = async ({
             flow: flow
         }
       } catch (error) {
-        console.error('Error al consultar flujo:', error);
+        logger.error('Error al consultar flujo:', error);
       }
 };
 

--- a/backend/src/services/FlowBuilderService/GetFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/GetFlowBuilderService.ts
@@ -1,6 +1,7 @@
 import { WebhookModel } from "../../models/Webhook";
 import User from "../../models/User";
 import { FlowBuilderModel } from "../../models/FlowBuilder";
+import logger from "../../utils/logger";
 
 interface Request {
   companyId: number;
@@ -31,7 +32,7 @@ const GetFlowBuilderService = async ({
             flow: flow
         }
       } catch (error) {
-        console.error('Error al consultar usuarios:', error);
+        logger.error('Error al consultar usuarios:', error);
       }
 };
 

--- a/backend/src/services/FlowBuilderService/ListFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/ListFlowBuilderService.ts
@@ -1,6 +1,7 @@
 import { WebhookModel } from "../../models/Webhook";
 import User from "../../models/User";
 import { FlowBuilderModel } from "../../models/FlowBuilder";
+import logger from "../../utils/logger";
 
 interface Request {
   companyId: number;
@@ -32,7 +33,7 @@ const ListFlowBuilderService = async ({
             flows: flowResult,
         }
       } catch (error) {
-        console.error('Error al consultar usuarios:', error);
+        logger.error('Error al consultar usuarios:', error);
       }
 };
 

--- a/backend/src/services/FlowBuilderService/UpdateFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/UpdateFlowBuilderService.ts
@@ -1,6 +1,7 @@
 import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   companyId: number;
@@ -22,7 +23,7 @@ const UpdateFlowBuilderService = async ({
       }
     })
 
-    console.log({ nameExist })
+    logger.info({ nameExist })
     
     if(nameExist){
       return 'exist'
@@ -34,7 +35,7 @@ const UpdateFlowBuilderService = async ({
 
     return 'ok';
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error
   }

--- a/backend/src/services/FlowBuilderService/UploadAllFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/UploadAllFlowBuilderService.ts
@@ -3,6 +3,7 @@ import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { FlowImgModel } from "../../models/FlowImg";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   userId: number;
@@ -57,7 +58,7 @@ const UploadAllFlowBuilderService = async ({
 
     return itemsNewNames;
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error;
   }

--- a/backend/src/services/FlowBuilderService/UploadAudioFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/UploadAudioFlowBuilderService.ts
@@ -3,6 +3,7 @@ import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { FlowImgModel } from "../../models/FlowImg";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   userId: number;
@@ -24,7 +25,7 @@ const UploadAudioFlowBuilderService = async ({
 
     return flowImg;
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error
   }

--- a/backend/src/services/FlowBuilderService/UploadImgFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/UploadImgFlowBuilderService.ts
@@ -2,6 +2,7 @@ import { FlowBuilderModel } from "../../models/FlowBuilder";
 import { FlowImgModel } from "../../models/FlowImg";
 import { WebhookModel } from "../../models/Webhook";
 import { randomString } from "../../utils/randomCode";
+import logger from "../../utils/logger";
 
 interface Request {
   userId: number;
@@ -23,7 +24,7 @@ const UploadImgFlowBuilderService = async ({
 
     return flowImg;
   } catch (error) {
-    console.error("Error al insertar el usuario:", error);
+    logger.error("Error al insertar el usuario:", error);
 
     return error
   }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -131,52 +131,47 @@ const App = () => {
   }, [mode]);
 
   useEffect(() => {
-    console.log("|=========== handleSaveSetting ==========|")
-    console.log("APP START")
-    console.log("|========================================|")
-   
-    
     getPublicSetting("primaryColorLight")
       .then((color) => {
         setPrimaryColorLight(color || "#0000FF");
       })
       .catch((error) => {
-        console.log("Error reading setting", error);
+        console.error("Error reading setting", error);
       });
     getPublicSetting("primaryColorDark")
       .then((color) => {
         setPrimaryColorDark(color || "#39ACE7");
       })
       .catch((error) => {
-        console.log("Error reading setting", error);
+        console.error("Error reading setting", error);
       });
     getPublicSetting("appLogoLight")
       .then((file) => {
         setAppLogoLight(file ? getBackendUrl() + "/public/" + file : defaultLogoLight);
       })
       .catch((error) => {
-        console.log("Error reading setting", error);
+        console.error("Error reading setting", error);
       });
     getPublicSetting("appLogoDark")
       .then((file) => {
         setAppLogoDark(file ? getBackendUrl() + "/public/" + file : defaultLogoDark);
       })
       .catch((error) => {
-        console.log("Error reading setting", error);
+        console.error("Error reading setting", error);
       });
     getPublicSetting("appLogoFavicon")
       .then((file) => {
         setAppLogoFavicon(file ? getBackendUrl() + "/public/" + file : defaultLogoFavicon);
       })
       .catch((error) => {
-        console.log("Error reading setting", error);
+        console.error("Error reading setting", error);
       });
     getPublicSetting("appName")
       .then((name) => {
         setAppName(name || "Chat-flow");
       })
       .catch((error) => {
-        console.log("!==== Erro ao carregar temas: ====!", error);
+        console.error("!==== Erro ao carregar temas: ====!", error);
         setAppName("chat-flow");
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -194,7 +189,7 @@ const App = () => {
         const { data } = response;
         window.localStorage.setItem("frontendVersion", data.version);
       } catch (error) {
-        console.log("Error fetching data", error);
+        console.error("Error fetching data", error);
       }
     }
     fetchVersionData();

--- a/frontend/src/components/AcceptTicketWithoutQueueModal/index.js
+++ b/frontend/src/components/AcceptTicketWithoutQueueModal/index.js
@@ -99,7 +99,6 @@ const handleSendMessage = async (id) => {
 		toastError(err);
 	}
 	
-	// console.log(ticket)
 	if (isGreetingMessage && (!ticket.isGroup || ticket.whatsapp?.groupAsTicket === "enabled") && ticket.status === "pending") {
 		const msg = `${settingMessage.greetingAcceptedMessage}`;
 		// const msg = `{{ms}} *{{name}}*, ${i18n.t("mainDrawer.appBar.user.myName")} *${user?.name}* ${i18n.t("mainDrawer.appBar.user.continuity")}.`;

--- a/frontend/src/components/ButtonModal/index.js
+++ b/frontend/src/components/ButtonModal/index.js
@@ -137,7 +137,6 @@ const ButtonModal = ({ modalOpen, onClose, ticketId }) => {
         copyText: copyText,
       };
 
-      console.log('PAYLOAD:', payload);
       if (isMounted.current) {
         await api.post(`/messages/copy/${ticketId}`, payload); // Envia a mensagem para a API
       }
@@ -249,7 +248,6 @@ const ButtonModal = ({ modalOpen, onClose, ticketId }) => {
       const reader = new FileReader();
       reader.onloadend = () => {
         setImageBase64(reader.result);
-        //  console.log('Image Base64:', reader.result); // Log the Base64 string
       };
       reader.readAsDataURL(file);
     }
@@ -257,7 +255,6 @@ const ButtonModal = ({ modalOpen, onClose, ticketId }) => {
 
 
   const createMessage = async () => {
-    console.log('createMessage chamada');
 
     try {
       if (selectedOption === "Lista") {

--- a/frontend/src/components/CampaignModal/index.js
+++ b/frontend/src/components/CampaignModal/index.js
@@ -295,8 +295,6 @@ const CampaignModal = ({
         queueId: selectedQueue || null
       };
 
-      //console.log(values);
-      //console.log(selectedWhatsapps);
 
       Object.entries(values).forEach(([key, value]) => {
         if (key === "scheduledAt" && value !== "" && value !== null) {
@@ -332,7 +330,6 @@ const CampaignModal = ({
       }
       toast.success(i18n.t("campaigns.toasts.success"));
     } catch (err) {
-      console.log(err);
       toastError(err);
     }
   };
@@ -595,7 +592,6 @@ const CampaignModal = ({
                         disabled={!campaignEditable}
                         value={whatsappId}
                         onChange={(event) => {
-                          console.log(event.target.value)
                           setWhatsappId(event.target.value)
                         }}
                         // renderValue={(selected) => (

--- a/frontend/src/components/CampaignModalPhrase/index.js
+++ b/frontend/src/components/CampaignModalPhrase/index.js
@@ -113,7 +113,6 @@ const CampaignModalPhrase = ({ open, onClose, FlowCampaignId, onSave }) => {
   const detailsPhrase = async flows => {
     setLoading(true);
     await api.get(`/flowcampaign/${FlowCampaignId}`).then(res => {
-      console.log("dete", res.data);
       setDataItem({
         name: res.data.details.name,
         phrase: res.data.details.phrase

--- a/frontend/src/components/ChatBots/options.js
+++ b/frontend/src/components/ChatBots/options.js
@@ -204,7 +204,6 @@ export default function VerticalLinearStepper(props) {
           setSteps(data);
           setLoading(false);
         } catch (err) {
-          console.log(err);
         }
       };
       fetchList();

--- a/frontend/src/components/CheckoutPage/CheckoutPage.js
+++ b/frontend/src/components/CheckoutPage/CheckoutPage.js
@@ -81,7 +81,6 @@ export default function CheckoutPage(props) {
       }
 
       const { data } = await api.post("/subscription", newValues);
-      console.log(data);
       setDatePayment(data)
       actions.setSubmitting(false);
       setActiveStep(activeStep + 1);

--- a/frontend/src/components/CompaniesModal/index.js
+++ b/frontend/src/components/CompaniesModal/index.js
@@ -227,8 +227,6 @@ const CompanyModal = ({ open, onClose, companyId }) => {
 										type="number"
 										fullWidth
 										style={
-											// console.log('touched', touched)
-											console.log('value', values)
 										}
 									/>
 								</div> */}

--- a/frontend/src/components/CompanyWhatsapps/index.js
+++ b/frontend/src/components/CompanyWhatsapps/index.js
@@ -119,8 +119,6 @@ const WhatsAppModalCompany = ({
   filteredWhatsapps,
   companyInfos
 }) => {
-  //console.log(filteredWhatsapps,"teste")
-  //console.log(companyInfos,"testeeeee")
   const classes = useStyles();
   const { user, socket } = useContext(AuthContext);
   const { list } = useCompanies();

--- a/frontend/src/components/ContactImport/index.js
+++ b/frontend/src/components/ContactImport/index.js
@@ -117,7 +117,6 @@ const ContactImport = () => {
   const processImport = async () => {
     setUploading(true);
 
-    console.log(selection)
 
     if (!selection.number) {
       toastError(i18n.t("contactImport.errors.noNumberField"));

--- a/frontend/src/components/ContactImportWpModal/index copy.js
+++ b/frontend/src/components/ContactImportWpModal/index copy.js
@@ -123,7 +123,6 @@ const ContactImportWpModal = ({ isOpen, handleClose, selectedTags, hideNum, user
     const exportData = allDatas.map((e) => {
       return { name: e.name, number: (hideNum && userProfile === "user" ? e.isGroup ? e.number : e.number.slice(0, -6) + "**-**" + e.number.slice(-2) : e.number), email: e.email, tags: e.tags };
     });
-    //console.log({ allDatas });
     let wb = XLSX.utils.book_new();
     let ws = XLSX.utils.json_to_sheet(exportData);
     XLSX.utils.book_append_sheet(wb, ws, "Contatos");

--- a/frontend/src/components/ContactImportWpModal/index.js
+++ b/frontend/src/components/ContactImportWpModal/index.js
@@ -60,7 +60,6 @@ const ContactImportWpModal = ({ isOpen, handleClose, selectedTags, hideNum, user
   }
 
   useEffect(() => {
-    console.log(contactsToImport?.length)
     if (contactsToImport?.length) {
       contactsToImport.map(async (item, index) => {
         setTimeout(async () => {
@@ -80,7 +79,6 @@ const ContactImportWpModal = ({ isOpen, handleClose, selectedTags, hideNum, user
               // toast.info(
               // );
             }
-            console.log("antes do import: ", item[0])
             await api.post(`/contactsImport`, {
               name: item.name,
               number: item.number.toString(),
@@ -105,7 +103,6 @@ const ContactImportWpModal = ({ isOpen, handleClose, selectedTags, hideNum, user
         const { data } = await api.get("/contacts/", {
           params: { searchParam: "", pageNumber: i, contactTag: JSON.stringify(selectedTags) },
         });
-        console.log(data)
         data.contacts.forEach((element) => {
           const tagsContact = element?.tags?.map(tag => tag?.name).join(', '); // Concatenando as tags com vírgula
           const contactWithTags = { ...element, tags: tagsContact }; // Substituindo as tags pelo valor concatenado
@@ -129,7 +126,6 @@ const ContactImportWpModal = ({ isOpen, handleClose, selectedTags, hideNum, user
     const exportData = allDatas.map((e) => {
       return { name: e.name, number: (hideNum && userProfile === "user" ? e.isGroup ? e.number : e.number.slice(0, -6) + "**-**" + e.number.slice(-2) : e.number), email: e.email, tags: e.tags };
     });
-    //console.log({ allDatas });
     let wb = XLSX.utils.book_new();
     let ws = XLSX.utils.json_to_sheet(exportData);
     XLSX.utils.book_append_sheet(wb, ws, "Contatos");
@@ -149,7 +145,6 @@ const ContactImportWpModal = ({ isOpen, handleClose, selectedTags, hideNum, user
         const data = XLSX.utils.sheet_to_json(ws);
         setContactsToImport(data)
       } catch (err) {
-        console.log(err);
         setContactsToImport([]);
       }
     };

--- a/frontend/src/components/ContactNotes/index.js
+++ b/frontend/src/components/ContactNotes/index.js
@@ -73,7 +73,6 @@ export function ContactNotes({ ticket }) {
     }
 
     const handleEdit = (note) => {
-        console.log(note)
         setEditingNote(note);
     };
 

--- a/frontend/src/components/ContactTagListModal/index.js
+++ b/frontend/src/components/ContactTagListModal/index.js
@@ -49,7 +49,6 @@ const ContactTagListModal = ({ open, onClose, tag }) => {
   const { user, socket } = useContext(AuthContext);
 
   useEffect(() => {
-    console.log("tagList", tagList)
   }, [tagList])
 
   useEffect(() => {

--- a/frontend/src/components/FileModal/index.js
+++ b/frontend/src/components/FileModal/index.js
@@ -152,7 +152,6 @@ const FilesModal = ({ open, onClose, fileListId, reload }) => {
             if (fileListId) {
                 const { data } = await api.put(`/files/${fileListId}`, fileData)
                 if (data.options.length > 0)
-                    // console.log(values.options)
                     uploadFiles(data.options, values.options, fileListId)
             } else {
                 const { data } = await api.post("/files", fileData);

--- a/frontend/src/components/FlowBuilderAddAudioModal/index.js
+++ b/frontend/src/components/FlowBuilderAddAudioModal/index.js
@@ -138,7 +138,6 @@ const FlowBuilderAddAudioModal = ({ open, onSave, onUpdate, data, close }) => {
             },
               error(err) {
                 alert("error");
-                console.log(err.message);
               }
           });
         } else {
@@ -148,7 +147,6 @@ const FlowBuilderAddAudioModal = ({ open, onSave, onUpdate, data, close }) => {
       });
 
       setTimeout(async () => {
-        console.log(formData);
         await api.post("/flowbuilder/audio", formData).then(res => {
           handleClose();
           onSave({

--- a/frontend/src/components/FlowBuilderAddImgModal/index.js
+++ b/frontend/src/components/FlowBuilderAddImgModal/index.js
@@ -135,7 +135,6 @@ const FlowBuilderAddImgModal = ({ open, onSave, onUpdate, data, close }) => {
             },
             error(err) {
               alert("erro");
-              console.log(err.message);
             }
           });
         } else {
@@ -145,7 +144,6 @@ const FlowBuilderAddImgModal = ({ open, onSave, onUpdate, data, close }) => {
       });
 
       setTimeout(async () => {
-        console.log(formData);
         await api.post("/flowbuilder/img", formData).then(res => {
           handleClose();
           onSave({

--- a/frontend/src/components/FlowBuilderAddOpenAIModal/index.js
+++ b/frontend/src/components/FlowBuilderAddOpenAIModal/index.js
@@ -95,7 +95,6 @@ const FlowBuilderOpenAIModal = ({ open, onSave, data, onUpdate, close }) => {
         title: "Editar OpenAI do fluxo",
         btn: "Salvar",
       });
-      console.log("FlowTybebotEdit", data);
       setIntegration({
         ...data.data.typebotIntegration,
       });

--- a/frontend/src/components/FlowBuilderAddQuestionModal/index.js
+++ b/frontend/src/components/FlowBuilderAddQuestionModal/index.js
@@ -74,7 +74,6 @@ const FlowBuilderAddQuestionModal = ({
         title: "Editar Perguta do fluxo",
         btn: "Salvar",
       });
-      console.log("FlowTybebotEdit", data.data.typebotIntegration);
       setMessage(data.data.typebotIntegration.message)
       setIntegration({
         ...data.data.typebotIntegration,

--- a/frontend/src/components/FlowBuilderAddTicketModal/index.js
+++ b/frontend/src/components/FlowBuilderAddTicketModal/index.js
@@ -73,13 +73,11 @@ const FlowBuilderTicketModal = ({
                     const { data: old } = await api.get("/queue");
                     setQueues(old)
                     const queue = old.find((item) => item.id === data.data.id)
-                    console.log('queue', queue)
                     if (queue) {
                         setQueueSelected(queue.id)
                     }
                     setActiveModal(true)
                 } catch (error) {
-                    console.log(error)
                 }
             })();
 
@@ -90,7 +88,6 @@ const FlowBuilderTicketModal = ({
                     setQueues(data)
                     setActiveModal(true)
                 } catch (error) {
-                    console.log(error)
                 }
             })()
         }

--- a/frontend/src/components/FlowBuilderAddTypebotModal/index.js
+++ b/frontend/src/components/FlowBuilderAddTypebotModal/index.js
@@ -91,7 +91,6 @@ const FlowBuilderTypebotModal = ({ open, onSave, data, onUpdate, close }) => {
         title: "Editar Typebot ao fluxo",
         btn: "Salvar",
       });
-      console.log("FlowTybebotEdit", data);
       setIntegration({
         ...data.data.typebotIntegration,
       });

--- a/frontend/src/components/FlowBuilderAddVideoModal/index.js
+++ b/frontend/src/components/FlowBuilderAddVideoModal/index.js
@@ -135,7 +135,6 @@ const FlowBuilderAddVideoModal = ({ open, onSave, onUpdate, data, close }) => {
             },
             error(err) {
               alert("erro");
-              console.log(err.message);
             }
           });
         } else {

--- a/frontend/src/components/FlowBuilderSingleBlockModal/index.js
+++ b/frontend/src/components/FlowBuilderSingleBlockModal/index.js
@@ -165,7 +165,6 @@ const FlowBuilderSingleBlockModal = ({
         value: value,
         number: newArrMessage[i],
       });
-      console.log("text");
     }
     //Todos os intervalos
     for (let i = 0; i < numberInterval; i++) {
@@ -182,7 +181,6 @@ const FlowBuilderSingleBlockModal = ({
         value: value,
         number: newArrInterval[i],
       });
-      console.log("int");
     }
 
     //Todas as imagens
@@ -319,7 +317,6 @@ const FlowBuilderSingleBlockModal = ({
       }
     }
 
-    console.log(elementsSequence);
 
     return elementsSequence;
   };
@@ -408,7 +405,6 @@ const FlowBuilderSingleBlockModal = ({
       const array = old;
       const index = array.indexOf(id);
       moveItemParaFrente(index);
-      console.log("id", id);
       if (index !== -1 && index < array.length - 1) {
         // Verifica se o elemento foi encontrado no array e não está na última posição
         const novoArray = [...array]; // Cria uma cópia do array original
@@ -1004,7 +1000,6 @@ const FlowBuilderSingleBlockModal = ({
             },
             error(err) {
               alert("erro");
-              console.log(err.message);
             },
           });
         } else {
@@ -1023,7 +1018,6 @@ const FlowBuilderSingleBlockModal = ({
               seq: elementsSeq,
               elements: handleElements(null),
             };
-            console.log("QUI", mountData);
             onUpdate({
               ...data,
               data: mountData,
@@ -1034,7 +1028,6 @@ const FlowBuilderSingleBlockModal = ({
 
             return;
           } catch (e) {
-            console.log(e);
             setLoading(false);
           }
           return;
@@ -1060,7 +1053,6 @@ const FlowBuilderSingleBlockModal = ({
             setLoading(false);
           })
           .catch((error) => {
-            console.log(error);
           });
       }, 1500);
     } else if (open === "create") {
@@ -1084,7 +1076,6 @@ const FlowBuilderSingleBlockModal = ({
             },
             error(err) {
               alert("erro");
-              console.log(err.message);
             },
           });
         } else {
@@ -1132,7 +1123,6 @@ const FlowBuilderSingleBlockModal = ({
             setLoading(false);
           })
           .catch((error) => {
-            console.log(error);
           });
       }, 1500);
     }

--- a/frontend/src/components/ForwardMessageModal/index.js
+++ b/frontend/src/components/ForwardMessageModal/index.js
@@ -44,7 +44,6 @@ const ForwardMessageModal = ({ messages, onClose, modalOpen }) => {
 					const { data } = await api.get("contacts", {
 						params: { searchParam },
 					});
-					console.log('contacts', data.contacts);
 					setOptionsContacts(data.contacts);
 					setLoading(false);
 				} catch (err) {

--- a/frontend/src/components/MessageInput/index.js
+++ b/frontend/src/components/MessageInput/index.js
@@ -588,7 +588,6 @@ const MessageInput = ({ ticketId, ticketStatus, droppedFiles, contactId, ticketC
 
     // Certifique-se de que a variável medias esteja preenchida antes de continuar
     if (!mediasUpload.length) {
-      console.log("Nenhuma mídia selecionada.");
       setLoading(false);
       return;
     }

--- a/frontend/src/components/MessageModal/index.js
+++ b/frontend/src/components/MessageModal/index.js
@@ -258,7 +258,6 @@ const MessageModal = ({ open, onClose, messageId, reload }) => {
         reload();
       } else {
         const response = await api.post("/schedules-message", formData);
-        console.log(response);
         toast.success(i18n.t("messageModal.success.save"));
         handleClose();
         reload();

--- a/frontend/src/components/MessagesList/index.js
+++ b/frontend/src/components/MessagesList/index.js
@@ -623,7 +623,6 @@ const hanldeReplyMessage = (e, message) => {
 };
 
 const checkMessageMedia = (message) => {
-  console.log(message)
   if (message.mediaType === "eventMessage") {
     try {
       // Parsear o dataJson diretamente da coluna do banco de dados
@@ -729,7 +728,6 @@ const checkMessageMedia = (message) => {
         if (viewOnceMessage.header?.imageMessage?.jpegThumbnail) {
             imagem = viewOnceMessage.header.imageMessage.jpegThumbnail;    
         } else {
-            console.log("Nenhuma imagem encontrada no header.");
         }
         return (
             <ButtonPreview 
@@ -824,11 +822,9 @@ const checkMessageMedia = (message) => {
           }
         }
       }
-      // console.log(message)
       return <VcardPreview contact={contact} numbers={obj[0]?.number} queueId={message?.ticket?.queueId} whatsappId={message?.ticket?.whatsappId} />
     } 
     else if (message.mediaType === "adMetaPreview") { // Adicionado para renderizar o componente de preview de anúncio
-      console.log("Entrou no MetaPreview");
       let [image, sourceUrl, title, body, messageUser] = message.body.split('|');
       return <AdMetaPreview image={image} sourceUrl={sourceUrl} title={title} body={body} messageUser={messageUser} />;
   }

--- a/frontend/src/components/MomentsUser/index.js
+++ b/frontend/src/components/MomentsUser/index.js
@@ -116,7 +116,6 @@ const DashboardManage = () => {
     (async () => {
       try {
         const { data } = await api.get("/usersMoments");
-        console.log(data)
         setTickets(data);
         setUpdate(!update);
       } catch (err) {
@@ -131,7 +130,6 @@ const DashboardManage = () => {
 
   useEffect(() => {
     const companyId = user.companyId;
-    console.log("socket painel")
     // const socket = socketManager.GetSocket();
   
     // const onConnect = () => {
@@ -167,7 +165,6 @@ const DashboardManage = () => {
   }, [socket]);
 
   const Moments = useMemo(() => {
-    // console.log(tickets)
     if (tickets && tickets.length > 0) {
       const ticketsByUser = tickets.reduce((userTickets, ticket) => {
         const user = ticket.user;

--- a/frontend/src/components/NotificationsPopOver/index.js
+++ b/frontend/src/components/NotificationsPopOver/index.js
@@ -115,7 +115,6 @@ const NotificationsPopOver = (volume) => {
 		soundAlertRef.current = play;
 
 		if (!("Notification" in window)) {
-			console.log("This browser doesn't support notifications");
 		} else {
 			Notification.requestPermission();
 		}

--- a/frontend/src/components/PixPreview/index.js
+++ b/frontend/src/components/PixPreview/index.js
@@ -26,8 +26,6 @@ const PixPreview = ({ companyId, avatarUser, avatarName, avatarUrl, name, numero
     const profileImage = avatarUser;
     const avatarUserUrl = `${backendUrl}/public/company${companyId}/user/${profileImage}`;
     
-    console.log("Avatar:", avatarUserUrl);
-    console.log("Avatar User URL:", avatarUserUrl);
     
 
     const handleCloseToast = () => setOpenToast(false);

--- a/frontend/src/components/PlansManager/index.js
+++ b/frontend/src/components/PlansManager/index.js
@@ -546,7 +546,6 @@ export default function PlansManager() {
 
     const handleSubmit = async (data) => {
         setLoading(true)
-        console.log(data)
         try {
             if (data.id !== undefined) {
                 await update(data)

--- a/frontend/src/components/QueueModal/index.js
+++ b/frontend/src/components/QueueModal/index.js
@@ -364,7 +364,6 @@ const QueueModal = ({ open, onClose, queueId, onEdit }) => {
   };
 
   const handleSaveBot = async (values) => {
-    console.log(values)
     try {
       if (queueId) {
         const { data } = await api.put(`/queue/${queueId}`, values);

--- a/frontend/src/components/QuickMessageDialog/index.js
+++ b/frontend/src/components/QuickMessageDialog/index.js
@@ -148,8 +148,6 @@ const QuickMessageDialog = ({ open, onClose, quickemessageId, reload }) => {
       }
       toast.success(i18n.t("quickMessages.toasts.success"));
       if (typeof reload == "function") {
-        console.log(reload);
-        console.log("0");
         reload();
       }
     } catch (err) {
@@ -172,8 +170,6 @@ const QuickMessageDialog = ({ open, onClose, quickemessageId, reload }) => {
       }));
       toast.success(i18n.t("quickMessages.toasts.deleted"));
       if (typeof reload == "function") {
-        console.log(reload);
-        console.log("1");
         reload();
       }
     }

--- a/frontend/src/components/ScheduleModal/index.js
+++ b/frontend/src/components/ScheduleModal/index.js
@@ -214,7 +214,6 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
 					setSchedule(prevState => {
 						return { ...prevState, ...data, sendAt: moment(data.sendAt).format('YYYY-MM-DDTHH:mm') };
 					});
-					console.log(data)
 					if (data.whatsapp) {
 						setSelectedWhatsapps(data.whatsapp.id);
 					}
@@ -352,8 +351,6 @@ const ScheduleModal = ({ open, onClose, scheduleId, contactId, cleanContact, rel
 			}));
 			toast.success(i18n.t("scheduleModal.toasts.deleted"));
 			if (typeof reload == "function") {
-				console.log(reload);
-				console.log("1");
 				reload();
 			}
 		}

--- a/frontend/src/components/SchedulesForm/index.js
+++ b/frontend/src/components/SchedulesForm/index.js
@@ -47,7 +47,6 @@ function SchedulesForm(props) {
   ]);
 
   useEffect(() => {
-    console.log(initialValues)
     if (isArray(initialValues) && initialValues.length > 0) {
       setSchedules(initialValues);
     }
@@ -55,7 +54,6 @@ function SchedulesForm(props) {
   }, [initialValues]);
 
   const handleSubmit = (data) => {
-    console.log(data)
     onSubmit(data);
   };
 

--- a/frontend/src/components/Settings/UploaderCert.js
+++ b/frontend/src/components/Settings/UploaderCert.js
@@ -191,7 +191,6 @@ const handleFileChange = (event) => {
 
       }
     } catch (error) {
-      console.log(error);
     }
   };
 

--- a/frontend/src/components/Settings/Whitelabel.js
+++ b/frontend/src/components/Settings/Whitelabel.js
@@ -157,9 +157,6 @@ export default function Whitelabel(props) {
   const { update } = useSettings();
 
   function updateSettingsLoaded(key, value) {
-    console.log("|=========== updateSettingsLoaded ==========|")
-    console.log(key, value)
-    console.log("|===========================================|")
     if (key === 'primaryColorLight' || key === 'primaryColorDark' || key === 'appName') {
       localStorage.setItem(key, value);
     };
@@ -216,7 +213,6 @@ export default function Whitelabel(props) {
         let progress = Math.round(
           (event.loaded * 100) / event.total
         );
-        console.log(
           `A imagem  está ${progress}% carregada... `
         );
       },
@@ -227,7 +223,6 @@ export default function Whitelabel(props) {
       console.error(
         `Houve um problema ao realizar o upload da imagem.`
       );
-      console.log(err);
     });
   };
 

--- a/frontend/src/components/Softphone/index.js
+++ b/frontend/src/components/Softphone/index.js
@@ -32,7 +32,6 @@ const setRingVolume =(newValue)=>{
 return true
 }
 
-console.log(setConnectOnStartToLocalStorage)
 
 function SoftPhone() {
   return (

--- a/frontend/src/components/TagTicketModal/index.js
+++ b/frontend/src/components/TagTicketModal/index.js
@@ -79,7 +79,6 @@ const TagModal = ({ open, onClose, tagId, reload }) => {
 	const classes = useStyles();
 	const { user } = useContext(AuthContext);
 	const [colorPickerModalOpen, setColorPickerModalOpen] = useState(false);
-    //console.log(user);
 
 
 	const initialState = {
@@ -96,7 +95,6 @@ const TagModal = ({ open, onClose, tagId, reload }) => {
 				if (!tagId) return;
 
 				const { data } = await api.get(`/tags/${tagId}`);
-                //console.log(data);
 				setTag(prevState => {
 					return { ...prevState, ...data };
 				});

--- a/frontend/src/components/Ticket/index.js
+++ b/frontend/src/components/Ticket/index.js
@@ -76,9 +76,6 @@ const Ticket = () => {
   const { companyId } = user;
 
   useEffect(() => {
-    console.log("======== Ticket ===========")
-    console.log(ticket)
-    console.log("===========================")
 }, [ticket])
 
   useEffect(() => {

--- a/frontend/src/components/TicketListItem/index.js
+++ b/frontend/src/components/TicketListItem/index.js
@@ -242,9 +242,6 @@ const TicketListItem = ({ ticket }) => {
     const { setCurrentTicket, setTabOpen } = useContext(TicketsContext);
 
     useEffect(() => {
-        console.log("======== TicketListItemCustom ===========")
-        console.log(ticket)
-        console.log("=========================================")
     }, [ticket])
 
     

--- a/frontend/src/components/TicketListItemCustom/index.js
+++ b/frontend/src/components/TicketListItemCustom/index.js
@@ -214,9 +214,6 @@ const TicketListItemCustom = ({ setTabOpen, ticket }) => {
     const { get: getSetting } = useCompanySettings();
 
     useEffect(() => {
-        console.log("======== TicketListItemCustom ===========")
-        console.log(ticket)
-        console.log("=========================================")
     }, [ticket])
 
     useEffect(() => {
@@ -226,7 +223,6 @@ const TicketListItemCustom = ({ setTabOpen, ticket }) => {
     }, []);
 
     const handleOpenAcceptTicketWithouSelectQueue = useCallback(() => {
-        // console.log(ticket)
         setAcceptTicketWithouSelectQueueOpen(true);
     }, []);
 
@@ -467,7 +463,6 @@ const TicketListItemCustom = ({ setTabOpen, ticket }) => {
                 button
                 dense
                 onClick={(e) => {
-                    console.log('e', e)
                     const isCheckboxClicked = (e.target.tagName.toLowerCase() === 'input' && e.target.type === 'checkbox')
                         || (e.target.tagName.toLowerCase() === 'svg' && e.target.type === undefined)
                         || (e.target.tagName.toLowerCase() === 'path' && e.target.type === undefined);
@@ -537,7 +532,6 @@ const TicketListItemCustom = ({ setTabOpen, ticket }) => {
                                 component="span"
                                 variant="body2"
                             // color="textSecondary"
-                            // style={console.log('ticket.lastMessage', ticket.lastMessage)}
                             >
                                 {ticket.lastMessage ? (
                                     <>

--- a/frontend/src/components/TicketsListCustom/index.js
+++ b/frontend/src/components/TicketsListCustom/index.js
@@ -94,7 +94,6 @@ const ticketSortDesc = (a, b) => {
 }
 
 const reducer = (state, action) => {
-    //console.log("action", action, state)
     const sortDir = action.sortDir;
     
     if (action.type === "LOAD_TICKETS") {
@@ -280,7 +279,6 @@ const TicketsListCustom = (props) => {
             ticket.queueId && selectedQueueIds.indexOf(ticket.queueId) === -1;
 
         const onCompanyTicketTicketsList = (data) => {
-            // console.log("onCompanyTicketTicketsList", data)
             if (data.action === "updateUnread") {
                 dispatch({
                     type: "RESET_UNREAD",
@@ -289,7 +287,6 @@ const TicketsListCustom = (props) => {
                     sortDir: sortTickets
                 });
             }
-            // console.log(shouldUpdateTicket(data.ticket))
             if (data.action === "update" &&
                 shouldUpdateTicket(data.ticket) && data.ticket.status === status) {
                 dispatch({
@@ -426,7 +423,6 @@ const TicketsListCustom = (props) => {
                         <>
                             {ticketsList.map((ticket) => (
                                 // <List key={ticket.id}>
-                                //     {console.log(ticket)}
                                 <TicketListItem
                                     ticket={ticket}
                                     key={ticket.id}

--- a/frontend/src/components/TicketsManagerTabs/index.js
+++ b/frontend/src/components/TicketsManagerTabs/index.js
@@ -422,7 +422,6 @@ const TicketsManagerTabs = () => {
       });
       handleSnackbarClose();
     } catch (err) {
-      console.log("Error: ", err);
     }
   };
 

--- a/frontend/src/components/UserModal/index.js
+++ b/frontend/src/components/UserModal/index.js
@@ -210,11 +210,9 @@ const UserModal = ({ open, onClose, userId }) => {
 			whatsappId,
 			queueIds: selectedQueueIds
 		};
-		console.log("userData", userData)
 		try {
 			if (userId) {
 				const { data } = await api.put(`/users/${userId}`, userData);
-				console.log("avatar", avatar, user?.profileImage, avatar?.name)
 				if (avatar && (!user?.profileImage || !user?.profileImage !== avatar.name))// getBasename(avatar)))
 					uploadAvatar(data)
 			} else {

--- a/frontend/src/components/VcardPreview/index.js
+++ b/frontend/src/components/VcardPreview/index.js
@@ -49,7 +49,6 @@ const VcardPreview = ({ contact, numbers, queueId, whatsappId }) => {
     //                 setContact(obj)
 
     //             } catch (err) {
-    //                 console.log(err)
     //                 toastError(err);
     //             }
     //         };
@@ -93,7 +92,6 @@ const VcardPreview = ({ contact, numbers, queueId, whatsappId }) => {
                     }
             
                 } catch (err) {
-                    console.log(err)
                     toastError(err);
                 }
             };

--- a/frontend/src/components/WhatsAppModal/index.js
+++ b/frontend/src/components/WhatsAppModal/index.js
@@ -250,13 +250,11 @@ const WhatsAppModal = ({ open, onClose, whatsAppId }) => {
         const { data } = await api.get(`whatsapp/${whatsAppId}?session=0`);
         if (data && data?.flowIdNotPhrase) {
           const { data: flowDefault } = await api.get(`flowbuilder/${data.flowIdNotPhrase}`)
-          console.log(flowDefault?.flow.id)
           const selectedFlowIdNotPhrase = flowDefault?.flow.id
           setFlowIdNotPhrase(selectedFlowIdNotPhrase)
         }
         if (data && data?.flowIdWelcome) {
           const { data: flowDefault } = await api.get(`flowbuilder/${data.flowIdWelcome}`)
-          console.log(flowDefault?.flow.id)
           const selectedFlowIdWelcome = flowDefault?.flow.id
           setFlowIdWelcome(selectedFlowIdWelcome)
         }
@@ -330,12 +328,10 @@ const WhatsAppModal = ({ open, onClose, whatsAppId }) => {
   }
 
   const handleChangeFlowIdNotPhrase = (e) => {
-    console.log(e.target.value)
     setFlowIdNotPhrase(e.target.value)
   }
 
   const handleChangeFlowIdWelcome = (e) => {
-    console.log(e.target.value)
     setFlowIdWelcome(e.target.value)
   }
 

--- a/frontend/src/hooks/useAuth.js/index.js
+++ b/frontend/src/hooks/useAuth.js/index.js
@@ -78,7 +78,6 @@ const useAuth = () => {
 
   useEffect(() => {
     if (Object.keys(user).length && user.id > 0) {
-      // console.log("Entrou useWhatsapp com user", Object.keys(user).length, Object.keys(socket).length ,user, socket)
       let io;
       if (!Object.keys(socket).length) {
         io = socketConnection({ user });
@@ -93,7 +92,6 @@ const useAuth = () => {
       });
 
       return () => {
-        // console.log("desconectou o company user ", user.id)
         io.off(`company-${user.companyId}-user`);
         // io.disconnect();
       };
@@ -209,7 +207,6 @@ Entre em contato com o Suporte para mais informações! `);
   const getCurrentUserInfo = async () => {
     try {
       const { data } = await api.get("/auth/me");
-      console.log(data)
       return data;
     } catch (_) {
       return null;

--- a/frontend/src/hooks/useSettings/index.js
+++ b/frontend/src/hooks/useSettings/index.js
@@ -16,7 +16,6 @@ const useSettings = () => {
       method: "PUT",
       data,
     });
-    console.log(responseData);
     return responseData;
   };
 

--- a/frontend/src/hooks/useTickets/index.js
+++ b/frontend/src/hooks/useTickets/index.js
@@ -65,8 +65,6 @@ const useTickets = ({
           }
         } else {
           try {
-            // console.log("ENTROU AQUI DASH")
-            // console.log(status,
             //   showAll,
             //   queueIds,
             //   format(sub(new Date(), { days: 30 }), 'yyyy-MM-dd'),
@@ -84,7 +82,6 @@ const useTickets = ({
               }
             })
 
-            // console.log(data)
             let tickets = [];
             tickets = data.filter(item => item.userId == userFilter);            
 

--- a/frontend/src/hooks/useUser/index.js
+++ b/frontend/src/hooks/useUser/index.js
@@ -35,7 +35,6 @@ const useUser = () => {
     });
 
     return () => {
-      console.log("OFF USERS SOCKET")
       socket.off("users");
     };
   }, [users]);

--- a/frontend/src/layout/MainListItems.js
+++ b/frontend/src/layout/MainListItems.js
@@ -312,7 +312,6 @@ const MainListItems = ({ collapsed, drawerClose }) => {
     if (user.id) {
       const companyId = user.companyId;
       //    const socket = socketManager.GetSocket();
-      // console.log('socket nListItems')
       const onCompanyChatMainListItems = (data) => {
         if (data.action === "new-message") {
           dispatch({ type: "CHANGE_CHAT", payload: data });

--- a/frontend/src/pages/AllConnections/index.js
+++ b/frontend/src/pages/AllConnections/index.js
@@ -547,7 +547,6 @@ const AllConnections = () => {
                       <TableRowSkeleton />
                     ) : (
                       <>
-                        {console.log(companies, whats)}
                         {companies?.length > 0 && companies.map(company => (
                           <TableRow key={company.id}>
                             <TableCell align="center">

--- a/frontend/src/pages/CampaignsConfig/index.js
+++ b/frontend/src/pages/CampaignsConfig/index.js
@@ -100,7 +100,6 @@ const CampaignsConfig = () => {
   useEffect(() => {
     api.get("/campaign-settings").then(({ data }) => {
       const settingsList = [];
-      console.log(data)
       if (Array.isArray(data) && data.length > 0) {
         data.forEach((item) => {
           settingsList.push([item.key, item.value]);

--- a/frontend/src/pages/Chat/ChatPopover.js
+++ b/frontend/src/pages/Chat/ChatPopover.js
@@ -117,7 +117,6 @@ export default function ChatPopover() {
     soundAlertRef.current = play;
 
     if (!("Notification" in window)) {
-      console.log("This browser doesn't support notifications");
     } else {
       Notification.requestPermission();
     }

--- a/frontend/src/pages/Chat/index.js
+++ b/frontend/src/pages/Chat/index.js
@@ -206,7 +206,6 @@ function Chat(props) {
 
     const onChatUser = (data) => {
 
-      console.log(data)
       if (data.action === "create") {
         setChats((prev) => [data.record, ...prev]);
       }
@@ -329,7 +328,7 @@ function Chat(props) {
       const { data } = await api.get("/chats");
       return data;
     } catch (err) {
-      console.log(err);
+      console.error(err);
     }
   };
 

--- a/frontend/src/pages/Contacts/index.js
+++ b/frontend/src/pages/Contacts/index.js
@@ -328,7 +328,6 @@ const Contacts = () => {
     };
 
     const handleimportChats = async () => {
-        console.log("handleimportChats")
         try {
             await api.post("/contacts/import/chats");
             history.go(0);

--- a/frontend/src/pages/FlowBuilderConfig/index.js
+++ b/frontend/src/pages/FlowBuilderConfig/index.js
@@ -525,7 +525,6 @@ export const FlowBuilderConfig = () => {
   };
 
   const doubleClick = (event, node) => {
-    console.log("NODE", node);
     setDataNode(node);
     if (node.type === "message") {
       setModalAddText("edit");
@@ -913,7 +912,6 @@ export const FlowBuilderConfig = () => {
                   tooltipOpen
                   tooltipPlacement={"right"}
                   onClick={() => {
-                    console.log(action.type);
                     clickActions(action.type);
                   }}
                 />

--- a/frontend/src/pages/FlowBuilderConfig/nodes/audioNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/audioNode.js
@@ -19,7 +19,6 @@ export default memo(({ data, isConnectable, id }) => {
         type="target"
         position="left"
         style={{ background: "#0000FF" }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       />
       <div

--- a/frontend/src/pages/FlowBuilderConfig/nodes/imgNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/imgNode.js
@@ -16,7 +16,6 @@ export default memo(({ data, isConnectable, id }) => {
         type="target"
         position="left"
         style={{ background: "#0000FF" }}
-        onConnect={(params) => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       />
       <div

--- a/frontend/src/pages/FlowBuilderConfig/nodes/intervalNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/intervalNode.js
@@ -35,7 +35,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: 'pointer'
         }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/menuNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/menuNode.js
@@ -37,7 +37,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: 'pointer'
         }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/messageNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/messageNode.js
@@ -27,7 +27,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: 'pointer'
         }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/openaiNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/openaiNode.js
@@ -13,7 +13,6 @@ import { SiOpenai } from "react-icons/si";
 
 export default memo(({ data, isConnectable, id }) => {
   const storageItems = useNodeStorage();
-  console.log(12, "ticketNode", data);
   return (
     <div
       style={{
@@ -35,7 +34,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: "pointer",
         }}
-        onConnect={(params) => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/questionNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/questionNode.js
@@ -40,7 +40,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: "pointer",
         }}
-        onConnect={(params) => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/randomizerNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/randomizerNode.js
@@ -34,7 +34,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: 'pointer'
         }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/singleBlockNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/singleBlockNode.js
@@ -38,7 +38,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: 'pointer'
         }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/ticketNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/ticketNode.js
@@ -10,7 +10,6 @@ import { Typography } from "@material-ui/core";
 
 export default memo(({ data, isConnectable, id }) => {
   const storageItems = useNodeStorage();
-  console.log(12, "ticketNode", data)
   return (
     <div
       style={{
@@ -32,7 +31,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: 'pointer'
         }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/typebotNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/typebotNode.js
@@ -13,7 +13,6 @@ import typebotIcon from "../../../assets/typebot-ico.png";
 
 export default memo(({ data, isConnectable, id }) => {
   const storageItems = useNodeStorage();
-  console.log(12, "ticketNode", data);
   return (
     <div
       style={{
@@ -35,7 +34,6 @@ export default memo(({ data, isConnectable, id }) => {
           left: "-12px",
           cursor: "pointer",
         }}
-        onConnect={(params) => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       >
         <ArrowForwardIos

--- a/frontend/src/pages/FlowBuilderConfig/nodes/videoNode.js
+++ b/frontend/src/pages/FlowBuilderConfig/nodes/videoNode.js
@@ -26,7 +26,6 @@ export default memo(({ data, isConnectable, id }) => {
         type="target"
         position="left"
         style={{ background: "#0000FF" }}
-        onConnect={params => console.log("handle onConnect", params)}
         isConnectable={isConnectable}
       />
       <div

--- a/frontend/src/pages/FlowDefault/index.js
+++ b/frontend/src/pages/FlowDefault/index.js
@@ -226,7 +226,6 @@ const FlowDefault = () => {
   };
 
   const handleSaveDefault = async () => {
-    console.log(configExist)
 
     let idWelcome = flowsDataObj.filter(item => item.name === flowSelectedWelcome)
     let idPhrase = flowsDataObj.filter(item => item.name === flowSelectedPhrase)

--- a/frontend/src/pages/ForgetPassWord/index.js
+++ b/frontend/src/pages/ForgetPassWord/index.js
@@ -109,7 +109,6 @@ const handleSendEmail = async (values) => {
     const response = await api.post(
       `${process.env.REACT_APP_BACKEND_URL}/forgetpassword/${email}`
     );
-    console.log("API Response:", response.data);
 
     if (response.data.status === 404) {
       toast.error(i18n.t("forgetPassword.toasts.emailNotFound"));
@@ -117,7 +116,6 @@ const handleSendEmail = async (values) => {
       toast.success(i18n.t("forgetPassword.toasts.emailSent"));
     }
   } catch (err) {
-    console.log("API Error:", err);
     toastError(err);
   }
 };
@@ -137,7 +135,6 @@ const handleSendEmail = async (values) => {
         toast.success(i18n.t("forgetPassword.toasts.passwordReset"));
         history.push("/login");
       } catch (err) {
-        console.log(err);
       }
     }
   };

--- a/frontend/src/pages/Kanban/index.js
+++ b/frontend/src/pages/Kanban/index.js
@@ -85,7 +85,6 @@ const Kanban = () => {
       setTags(fetchedTags);
       fetchTickets();
     } catch (error) {
-      console.log(error);
     }
   };
 
@@ -100,7 +99,6 @@ const Kanban = () => {
       });
       setTickets(data.tickets);
     } catch (err) {
-      console.log(err);
       setTickets([]);
     }
   };
@@ -259,7 +257,6 @@ const Kanban = () => {
       await fetchTickets(jsonString);
       popularCards(jsonString);
     } catch (err) {
-      console.log(err);
     }
   };
 

--- a/frontend/src/pages/Login/index--.js
+++ b/frontend/src/pages/Login/index--.js
@@ -132,7 +132,6 @@ const Login = () => {
         setUserCreation(data === "enabled");
       })
       .catch((error) => {
-        console.log("Erro ao ler a configuração", error);
       });
   }, [getPublicSetting]);
 

--- a/frontend/src/pages/QuickMessages/index.js
+++ b/frontend/src/pages/QuickMessages/index.js
@@ -36,12 +36,8 @@ import { AuthContext } from "../../context/Auth/AuthContext";
 
 const reducer = (state, action) => {
   if (action.type === "LOAD_QUICKMESSAGES") {
-    //console.log("aqui");
-    //console.log(action);
-    //console.log(action.payload);
     const quickmessages = action.payload;
     const newQuickmessages = [];
-    //console.log(newQuickmessages);
 
     if (isArray(quickmessages)) {
       quickmessages.forEach((quickemessage) => {
@@ -178,7 +174,6 @@ const Quickemessages = () => {
   };
 
   const handleEditQuickemessage = (quickemessage) => {
-    //console.log(quickemessage);
     setSelectedQuickemessage(quickemessage);
     setQuickMessageDialogOpen(true);
   };

--- a/frontend/src/pages/Reports/index.js
+++ b/frontend/src/pages/Reports/index.js
@@ -193,7 +193,6 @@ const Reports = () => {
         }
       });
 
-      console.log(ticketsData)
       const ws = XLSX.utils.json_to_sheet(ticketsData);
       const wb = XLSX.utils.book_new();
 
@@ -213,7 +212,6 @@ const Reports = () => {
 
   const handleFilter = async (pageNumber) => {
     setLoading(true); // Define o estado de loading como true durante o carregamento
-    console.log(onlyRated)
     try {
       const data = await getReport({
         searchParam,

--- a/frontend/src/serviceWorker.js
+++ b/frontend/src/serviceWorker.js
@@ -1,12 +1,10 @@
 export function register() {
-  console.log("Registrando service worker", navigator)
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
       navigator.serviceWorker.register(swUrl)
         .then((registration) => {
-          console.log('Service worker registrado com sucesso!', registration);
         })
         .catch((error) => {
           console.error('Erro durante o registro do service worker:', error);

--- a/frontend/src/services/SocketWorker.js
+++ b/frontend/src/services/SocketWorker.js
@@ -25,11 +25,11 @@ class SocketWorker {
     });
 
     this.socket.on("connect", () => {
-      console.log("Conectado al servidor Socket.IO");
+      // connection established
     });
 
     this.socket.on("disconnect", () => {
-      console.log("Desconectado del servidor Socket.IO");
+      // connection lost
       this.reconnectAfterDelay();
     });
   }
@@ -73,14 +73,12 @@ class SocketWorker {
       this.socket.disconnect();
       this.socket = null
       this.instance = null
-      console.log("Socket desconectado manualmente");
     }
   }
 
   reconnectAfterDelay() {
     setTimeout(() => {
       if (!this.socket || !this.socket.connected) {
-        console.log("Intentando reconectar tras la desconexión");
         this.connect();
       }
     }, 1000);

--- a/frontend/src/utils/formatToHtmlFormat.js
+++ b/frontend/src/utils/formatToHtmlFormat.js
@@ -11,6 +11,6 @@ export default function formatToHtmlFormat(editorState) {
 
     return htmlText;
   } catch (error) {
-    console.log(error);
+    console.error(error);
   }
 }


### PR DESCRIPTION
## Summary
- use centralized logger instead of console in FlowBuilder services
- strip debug console logs from frontend and key utilities

## Testing
- `npm test` (backend) *(fails: sequelize not found)*
- `npm test` (frontend) *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_689175a26dc88333adc94190141c5b7b