### PR TITLE
chore: enforce cross origin policies

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -80,10 +80,10 @@ app.use(
         connectSrc: cspConnectSrc
       }
     },
-    // Desabilitados para evitar bloqueio de recursos externos necessários
-    crossOriginResourcePolicy: false,
-    crossOriginEmbedderPolicy: false,
-    crossOriginOpenerPolicy: false,
+    // Políticas de origem cruzada
+    crossOriginResourcePolicy: { policy: "same-origin" },
+    crossOriginEmbedderPolicy: { policy: "credentialless" },
+    crossOriginOpenerPolicy: { policy: "same-origin" },
     hsts: { maxAge: 31536000, includeSubDomains: true }
   })
 );


### PR DESCRIPTION
## Summary
- replace disabled cross-origin headers with explicit helmet policies

## Testing
- `SKIP_DB=true npm test` *(fails: jest not found)*
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for eslint-config-prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68922b9b7e7c8333826052ecb48a4ed7