### PR TITLE
feat: allow configurable timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@
    export JWT_REFRESH_SECRET="tu_jwt_refresh_secret"
    export DEPLOY_PASSWORD="tu_contraseña_deploy"
    export MYSQL_ROOT_PASSWORD="tu_contraseña_mysql_root"
-export DB_PASS="tu_contraseña_bd"
+   export DB_PASS="tu_contraseña_bd"
   ```
+
+4. Opcional: establece la variable `TZ` para definir la zona horaria del servidor (por defecto se usa `UTC`):
+   ```bash
+   export TZ="America/Bogota" # Ejemplo
+   ```
 
 ### Activar HTTPS
 

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -3,7 +3,8 @@ import moment from 'moment-timezone';
 
 // Función para obtener el timestamp con huso horario
 const timezoned = () => {
-  return moment().tz('America/Bogota').format('DD-MM-YYYY HH:mm:ss');
+  const timezone = process.env.TZ || 'UTC'; // Usa la zona horaria definida en TZ o UTC por defecto
+  return moment().tz(timezone).format('DD-MM-YYYY HH:mm:ss');
 };
 
 const logger = pino({


### PR DESCRIPTION
## Summary
- allow logger to respect TZ env var or fall back to UTC
- document how to set TZ when deploying

## Testing
- `SKIP_DB=true npm test` (fails: jest not found)
- `npm install --legacy-peer-deps` (fails: 403 fetching eslint-config-prettier)
- `npm run lint` (fails: missing @typescript-eslint/eslint-plugin)


------
https://chatgpt.com/codex/tasks/task_e_68922fc610108333bf06fde0f6d3b878