### PR TITLE
chore(frontend): update axios and cleanup build scripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,7 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.0.4",
     "@testing-library/user-event": "^12.1.7",
-    "axios": "^0.21.1",
+    "axios": "^1.7.7",
     "bootstrap": "^5.2.3",
     "caniuse-lite": "^1.0.30001616",
       "chart.js": "^3.9.1",
@@ -85,7 +85,7 @@
     "react-youtube": "^10.1.0",
     "reactflow": "^11.7.4",
     "recharts": "^2.0.2",
-    "socket.io-client": "^4.7.4",
+    "socket.io-client": "^4.7.5",
     "styled-components": "^5.3.6",
     "use-debounce": "^7.0.0",
     "use-sound": "^2.0.1",
@@ -96,8 +96,8 @@
   },
   "scripts": {
   "start": "react-scripts start",
-  "build": "NODE_OPTIONS=--openssl-legacy-provider GENERATE_SOURCEMAP=false react-scripts build",
-  "builddev": "NODE_OPTIONS=--openssl-legacy-provider react-scripts build",
+  "build": "GENERATE_SOURCEMAP=false react-scripts build",
+  "builddev": "react-scripts build",
   "test": "react-scripts test",
   "eject": "react-scripts eject"
 },


### PR DESCRIPTION
## Summary
- update axios and socket.io-client
- remove legacy NODE_OPTIONS from build scripts

## Testing
- `npm outdated` *(fails: 403 Forbidden)*
- `npm test` *(fails: react-scripts not found)*
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923aee66608333a739c78bc88d82eb