### PR TITLE
refactor: use explicit return values in flow builder service

### DIFF
--- a/backend/src/controllers/FlowBuilderController.ts
+++ b/backend/src/controllers/FlowBuilderController.ts
@@ -25,17 +25,17 @@ export const createFlow = async (
   const userId = parseInt(req.user.id);
   const { companyId } = req.user;
 
-  const flow = await CreateFlowBuilderService({
+  const result = await CreateFlowBuilderService({
     userId,
     name,
     companyId
   });
 
-  if(flow === 'exist'){
-    return res.status(402).json('exist')
+  if (result === "exist") {
+    return res.status(402).json("exist");
   }
 
-  return res.status(200).json(flow);
+  return res.status(200).json("ok");
 };
 
 export const updateFlow = async (
@@ -45,13 +45,13 @@ export const updateFlow = async (
   const { companyId } = req.user;
   const { flowId, name } = req.body;
 
-  const flow = await UpdateFlowBuilderService({ companyId, name, flowId });
+  const result = await UpdateFlowBuilderService({ companyId, name, flowId });
 
-  if(flow === 'exist'){
-    return res.status(402).json('exist')
+  if (result === "exist") {
+    return res.status(402).json("exist");
   }
 
-  return res.status(200).json(flow);
+  return res.status(200).json("ok");
 };
 
 export const deleteFlow = async (

--- a/backend/src/services/FlowBuilderService/CreateFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/CreateFlowBuilderService.ts
@@ -1,6 +1,4 @@
 import { FlowBuilderModel } from "../../models/FlowBuilder";
-import { WebhookModel } from "../../models/Webhook";
-import { randomString } from "../../utils/randomCode";
 import logger from "../../utils/logger";
 
 interface Request {
@@ -13,7 +11,7 @@ const CreateFlowBuilderService = async ({
   userId,
   name,
   companyId
-}: Request): Promise<FlowBuilderModel | string> => {
+}: Request): Promise<"ok" | "exist"> => {
   try {
     
     const nameExist = await FlowBuilderModel.findOne({
@@ -24,21 +22,20 @@ const CreateFlowBuilderService = async ({
     })
 
 
-    if(nameExist){
-      return 'exist'
+    if (nameExist) {
+      return "exist";
     }
 
-    const flow = await FlowBuilderModel.create({
+    await FlowBuilderModel.create({
       user_id: userId,
       company_id: companyId,
-      name: name,
+      name
     });
 
-    return flow;
+    return "ok";
   } catch (error) {
     logger.error("Error al insertar el usuario:", error);
-
-    return error
+    throw error;
   }
 };
 

--- a/backend/src/services/FlowBuilderService/UpdateFlowBuilderService.ts
+++ b/backend/src/services/FlowBuilderService/UpdateFlowBuilderService.ts
@@ -1,6 +1,4 @@
 import { FlowBuilderModel } from "../../models/FlowBuilder";
-import { WebhookModel } from "../../models/Webhook";
-import { randomString } from "../../utils/randomCode";
 import logger from "../../utils/logger";
 
 interface Request {
@@ -13,7 +11,7 @@ const UpdateFlowBuilderService = async ({
   companyId,
   name,
   flowId
-}: Request): Promise<String> => {
+}: Request): Promise<"ok" | "exist"> => {
   try {
 
     const nameExist = await FlowBuilderModel.findOne({
@@ -23,21 +21,21 @@ const UpdateFlowBuilderService = async ({
       }
     })
 
-    logger.info({ nameExist })
-    
-    if(nameExist){
-      return 'exist'
+    logger.info({ nameExist });
+
+    if (nameExist) {
+      return "exist";
     }
 
-    const flow = await FlowBuilderModel.update({ name }, {
-      where: {id: flowId, company_id: companyId}
-    });
+    await FlowBuilderModel.update(
+      { name },
+      { where: { id: flowId, company_id: companyId } }
+    );
 
-    return 'ok';
+    return "ok";
   } catch (error) {
     logger.error("Error al insertar el usuario:", error);
-
-    return error
+    throw error;
   }
 };
 


### PR DESCRIPTION
## Summary
- return explicit status from flow builder creation/update services
- adjust flow builder controller for new status responses

## Testing
- `SKIP_DB=true npm test` *(fails: jest not found)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden for eslint-config-prettier)*

------
https://chatgpt.com/codex/tasks/task_e_68923c405b508333baef2592794abe2a